### PR TITLE
DO NOT SUBMIT, Small change to make collectRemaining() use a prefetch

### DIFF
--- a/src/iterators/lazy_iterator.ts
+++ b/src/iterators/lazy_iterator.ts
@@ -160,11 +160,13 @@ export abstract class LazyIterator<T> {
    *   when the stream is exhausted.
    */
   async collectRemaining(): Promise<T[]> {
+    const stream = this.prefetch(100);
+    
     const result: T[] = [];
-    let x = await this.next();
+    let x = await stream.next();
     while (!x.done) {
       result.push(x.value);
-      x = await this.next();
+      x = await stream.next();
     }
     return result;
   }


### PR DESCRIPTION
This helps reveal potential problems with the internals. 18 out of 99 unit tests fail with this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/11)
<!-- Reviewable:end -->
