### PR TITLE
Fix rollup setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "coverage/": true,
+    "dist/": true,
+    "**/bundle.js": true,
+    "**/yarn.lock": true
+  },
+  "tslint.enable": true,
+  "tslint.run": "onType",
+  "tslint.configFile": "tslint.json",
+  "files.trimTrailingWhitespace": true,
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "[typescript]": {
+    "editor.formatOnSave": true
+  },
+  "[javascript]": {
+    "editor.formatOnSave": true
+  },
+  "editor.rulers": [80],
+  "clang-format.style": "Google",
+  "files.insertFinalNewline": true,
+  "editor.detectIndentation": false,
+  "editor.wrappingIndent": "none",
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "clang-format.executable": "${workspaceRoot}/node_modules/.bin/clang-format"
+}


### PR DESCRIPTION
Fix rollup setup and make tf-data(.min).js work in the browser. Fixes https://github.com/tensorflow/tfjs-data/issues/73

FYI, this assumes the `index.ts` will get fixed not to export it's own "data" namespace, which is being addressed in #72

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/76)
<!-- Reviewable:end -->
