### PR TITLE
Conditionally require `node-fetch` (only in node)

### DIFF
--- a/src/iterators/url_chunk_iterator.ts
+++ b/src/iterators/url_chunk_iterator.ts
@@ -17,7 +17,6 @@
  */
 
 import {ENV} from '@tensorflow/tfjs-core';
-import {default as nodeFetch} from 'node-fetch';
 import {FileChunkIterator, FileChunkIteratorOptions} from './file_chunk_iterator';
 
 /**
@@ -41,6 +40,8 @@ export async function urlChunkIterator(
   } else {
     // TODO(kangyizhang): Provide argument for users to use http.request with
     // headers in node.
+    // tslint:disable-next-line:no-require-imports
+    const nodeFetch = require('node-fetch');
     if (typeof url !== 'string') {
       throw new Error(
           'URL must be a string. Request objects are not supported ' +


### PR DESCRIPTION
Fixes tensorflow/tfjs#960.

This an alternative solution to https://github.com/tensorflow/tfjs-data/pull/102

Tested that in runs in browser, node and observablehq

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/103)
<!-- Reviewable:end -->
