### PR TITLE
edits publish-local to call build-npm, which generates esm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build-npm": "./scripts/build-npm.sh",
     "publish-npm": "./scripts/publish-npm.sh",
     "link-local": "yalc link",
-    "publish-local": "rimraf dist/ && yarn build && yalc push",
+    "publish-local": "rimraf dist/ && yarn build-npm && yalc push",
     "test": "karma start",
     "test-node": "ts-node src/test_node.ts",
     "test-travis": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun",


### PR DESCRIPTION
Without this change, when yalc linking tfjs-data to a web project, the server will fail with the following error:

```
Error: ENOENT: no such file or directory, open '/.../tfjs-examples/data-csv/node_modules/@tensorflow/tfjs-data/dist/tf-data.esm.js'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/120)
<!-- Reviewable:end -->
