### PR TITLE
Add size in dataset class

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-uglify": "~3.0.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
-    "typescript": "2.8.3",
+    "typescript": "3.2.2",
     "yalc": "^1.0.0-pre.23"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-uglify": "~3.0.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
-    "typescript": "3.2.2",
+    "typescript": "2.9.2",
     "yalc": "^1.0.0-pre.23"
   },
   "scripts": {

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -62,6 +62,12 @@ export abstract class Dataset<T extends DataElement> {
    */
   abstract async iterator(): Promise<LazyIterator<T>>;
 
+  protected readonly size: number = Infinity;
+
+  getSize(): number {
+    return this.size;
+  }
+
   // TODO(soergel): Make Datasets report whether repeated iterator() calls
   // produce the same result (e.g., reading from a file) or different results
   // (e.g., from the webcam).  Currently we don't make this distinction but it
@@ -393,8 +399,10 @@ export abstract class Dataset<T extends DataElement> {
  * ```
  */
 export function datasetFromIteratorFn<T extends DataElement>(
-    iteratorFn: () => Promise<LazyIterator<T>>): Dataset<T> {
+    iteratorFn: () => Promise<LazyIterator<T>>, size = Infinity): Dataset<T> {
   return new class extends Dataset<T> {
+    size = size;
+
     /*
      * Provide a new stream of elements.  Note this will also start new streams
      * from any underlying `Dataset`s.
@@ -424,7 +432,8 @@ export function datasetFromIteratorFn<T extends DataElement>(
  */
 /** @doc {heading: 'Data', subheading: 'Creation', namespace: 'data'} */
 export function array<T extends DataElement>(items: T[]): Dataset<T> {
-  return datasetFromIteratorFn(async () => iteratorFromItems(items));
+  return datasetFromIteratorFn(
+      async () => iteratorFromItems(items), items.length);
 }
 
 /**

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -62,7 +62,7 @@ export abstract class Dataset<T extends DataElement> {
    */
   abstract async iterator(): Promise<LazyIterator<T>>;
 
-  protected readonly size: number = Infinity;
+  protected readonly size: number;
 
   getSize(): number {
     return this.size;
@@ -399,7 +399,7 @@ export abstract class Dataset<T extends DataElement> {
  * ```
  */
 export function datasetFromIteratorFn<T extends DataElement>(
-    iteratorFn: () => Promise<LazyIterator<T>>, size = Infinity): Dataset<T> {
+    iteratorFn: () => Promise<LazyIterator<T>>, size?: number): Dataset<T> {
   return new class extends Dataset<T> {
     size = size;
 

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -124,11 +124,11 @@ export abstract class Dataset<T extends DataElement> {
     } else if (this.size >= 0 && smallLastBatch) {
       // If the size of this dataset is known and include small last batch, the
       // new size is full batch count plus last batch.
-      size = this.size / batchSize + 1;
+      size = Math.floor(this.size / batchSize) + 1;
     } else if (this.size >= 0 && !smallLastBatch) {
       // If the size of this dataset is known and not include small last batch,
       // the new size is full batch count.
-      size = this.size / batchSize;
+      size = Math.floor(this.size / batchSize);
     } else {
       // If current dataset size is undefined, new size is undefined.
       size = undefined;

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -117,7 +117,8 @@ export abstract class Dataset<T extends DataElement> {
   /** @doc {heading: 'Data', subheading: 'Classes'} */
   batch(batchSize: number, smallLastBatch = true): Dataset<DataElement> {
     const base = this;
-    tf.util.assert(batchSize > 0, 'batchSize need to be positive!');
+    tf.util.assert(batchSize > 0, `batchSize need to be positive, but it is
+      ${batchSize}`);
     let size;
     if (this.size === Infinity || this.size == null) {
       // If the size of this dataset is infinity or null, the new size keeps the
@@ -126,7 +127,7 @@ export abstract class Dataset<T extends DataElement> {
     } else if (smallLastBatch) {
       // If the size of this dataset is known and include small last batch, the
       // new size is full batch count plus last batch.
-      size = Math.floor(this.size / batchSize) + 1;
+      size = Math.ceil(this.size / batchSize);
     } else {
       // If the size of this dataset is known and not include small last batch,
       // the new size is full batch count.
@@ -164,7 +165,7 @@ export abstract class Dataset<T extends DataElement> {
       // sum the size of these two datasets.
       size = this.size + dataset.size;
     } else {
-      // If none of these two datasets has infinity size and any of these two
+      // If neither of these two datasets has infinity size and any of these two
       // datasets' size is null, the new size is null.
       size = null;
     }

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -632,12 +632,20 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
   });
 
   it('can get correct size of dataset from objects array', async () => {
-    const a = tfd.array([{'item': 1}, {'item': 2}, {'item': 3}]);
-    expect(a.getSize()).toEqual(3);
+    const ds = tfd.array([{'item': 1}, {'item': 2}, {'item': 3}]);
+    expect(ds.getSize()).toEqual(3);
   });
 
   it('can get correct size of dataset from number array', async () => {
-    const a = tfd.array([1, 2, 3, 4, 5]);
-    expect(a.getSize()).toEqual(5);
+    const ds = tfd.array([1, 2, 3, 4, 5]);
+    expect(ds.getSize()).toEqual(5);
+  });
+
+  it('size is undefined if dataset may exhausted randomly', async () => {
+    let i = -1;
+    const func = () =>
+        ++i < 7 ? {value: i, done: false} : {value: null, done: true};
+    const ds = tfd.generator(func);
+    expect(ds.getSize()).toBeUndefined();
   });
 });

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -633,12 +633,17 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
 
   it('can get correct size of dataset from objects array', async () => {
     const ds = tfd.array([{'item': 1}, {'item': 2}, {'item': 3}]);
-    expect(ds.getSize()).toEqual(3);
+    expect(ds.size).toEqual(3);
   });
 
   it('can get correct size of dataset from number array', async () => {
     const ds = tfd.array([1, 2, 3, 4, 5]);
-    expect(ds.getSize()).toEqual(5);
+    expect(ds.size).toEqual(5);
+  });
+
+  it('can get size 0 from empty dataset', async () => {
+    const ds = tfd.array([]);
+    expect(ds.size).toEqual(0);
   });
 
   it('size is undefined if dataset may exhausted randomly', async () => {
@@ -646,6 +651,22 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
     const ds = tfd.generator(func);
-    expect(ds.getSize()).toBeUndefined();
+    expect(ds.size).toBeUndefined();
   });
+
+  fit('zipping an array of datasets with primitive elements has correct size',
+      async () => {
+        const a = tfd.array([1, 2, 3]);
+        const b = tfd.array([4, 5, 6, 7, 8]);
+        const result = await tfd.zip([a, b]);
+        expect(result.size).toEqual(3);
+      });
+
+  fit('zipping an array of datasets with object elements has correct size',
+      async () => {
+        const a = tfd.array([{a: 1}, {a: 2}, {a: 3}]);
+        const b = tfd.array([{b: 4}, {b: 5}, {b: 6}, {b: 7}, {b: 8}]);
+        const result = await tfd.zip([a, b]);
+        expect(result.size).toEqual(3);
+      });
 });

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -654,19 +654,122 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     expect(ds.size).toBeUndefined();
   });
 
-  fit('zipping an array of datasets with primitive elements has correct size',
-      async () => {
-        const a = tfd.array([1, 2, 3]);
-        const b = tfd.array([4, 5, 6, 7, 8]);
-        const result = await tfd.zip([a, b]);
-        expect(result.size).toEqual(3);
-      });
+  it('repeat dataset has correct size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).repeat(3);
+    expect(ds.size).toEqual(15);
+  });
 
-  fit('zipping an array of datasets with object elements has correct size',
-      async () => {
-        const a = tfd.array([{a: 1}, {a: 2}, {a: 3}]);
-        const b = tfd.array([{b: 4}, {b: 5}, {b: 6}, {b: 7}, {b: 8}]);
-        const result = await tfd.zip([a, b]);
-        expect(result.size).toEqual(3);
-      });
+  it('repeat dataset forever has infinity size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).repeat();
+    expect(ds.size).toEqual(Infinity);
+  });
+
+  it('repeat undefined size dataset has undefined size', async () => {
+    let i = -1;
+    const func = () =>
+        ++i < 7 ? {value: i, done: false} : {value: null, done: true};
+    const ds = tfd.generator(func).repeat(3);
+    expect(ds.size).toBeUndefined();
+  });
+
+  it('take dataset has correct size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).take(3);
+    expect(ds.size).toEqual(3);
+  });
+
+  it('take dataset without enough elements has correct size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).take(10);
+    expect(ds.size).toEqual(5);
+  });
+
+  it('take dataset with undefined size has undefined size', async () => {
+    let i = -1;
+    const func = () =>
+        ++i < 7 ? {value: i, done: false} : {value: null, done: true};
+    const ds = tfd.generator(func).take(3);
+    expect(ds.size).toBeUndefined();
+  });
+
+  it('take dataset with infinity elements has correct size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).repeat().take(10);
+    expect(ds.size).toEqual(10);
+  });
+
+  it('skip dataset has correct size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).skip(2);
+    expect(ds.size).toEqual(3);
+  });
+
+  it('skip dataset without enough elements has correct size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).skip(10);
+    expect(ds.size).toEqual(0);
+  });
+
+  it('skip dataset with undefined size has undefined size', async () => {
+    let i = -1;
+    const func = () =>
+        ++i < 7 ? {value: i, done: false} : {value: null, done: true};
+    const ds = tfd.generator(func).skip(3);
+    expect(ds.size).toBeUndefined();
+  });
+
+  it('skip dataset with infinity elements has infinity size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).repeat().skip(10);
+    expect(ds.size).toEqual(Infinity);
+  });
+
+  it('batch dataset with small last batch has correct size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5, 6, 7]).batch(2, true);
+    expect(ds.size).toEqual(4);
+  });
+
+  it('batch dataset without small last batch has correct size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5, 6, 7]).batch(2, false);
+    expect(ds.size).toEqual(3);
+  });
+
+  it('batch dataset with undefined size has undefined size', async () => {
+    let i = -1;
+    const func = () =>
+        ++i < 7 ? {value: i, done: false} : {value: null, done: true};
+    const ds = tfd.generator(func).batch(2);
+    expect(ds.size).toBeUndefined();
+  });
+
+  it('batch dataset with infinity elements has infinity size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).repeat().batch(2);
+    expect(ds.size).toEqual(Infinity);
+  });
+
+  it('zipping an array of datasets with primitive elements has correct size',
+     async () => {
+       const a = tfd.array([1, 2, 3]);
+       const b = tfd.array([4, 5, 6, 7, 8]);
+       const result = await tfd.zip([a, b]);
+       expect(result.size).toEqual(3);
+     });
+
+  it('zipping an array of datasets with object elements has correct size',
+     async () => {
+       const a = tfd.array([{a: 1}, {a: 2}, {a: 3}]);
+       const b = tfd.array([{b: 4}, {b: 5}, {b: 6}, {b: 7}, {b: 8}]);
+       const result = await tfd.zip([a, b]);
+       expect(result.size).toEqual(3);
+     });
+
+  it('zipping an object of datasets with primitive elements has correct size',
+     async () => {
+       const a = tfd.array([1, 2, 3]);
+       const b = tfd.array([4, 5, 6, 7, 8]);
+       const result = await tfd.zip({'a': a, 'b': b});
+       expect(result.size).toEqual(3);
+     });
+
+  it('zipping an object of datasets with object elements has correct size',
+     async () => {
+       const a = tfd.array([{a: 1}, {a: 2}, {a: 3}]);
+       const b = tfd.array([{b: 4}, {b: 5}, {b: 6}, {b: 7}, {b: 8}]);
+       const result = await tfd.zip({'a': a, 'b': b});
+       expect(result.size).toEqual(3);
+     });
 });

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -651,7 +651,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
     const ds = tfd.generator(func);
-    expect(ds.size).toBeUndefined();
+    expect(ds.size).toBeNull();
   });
 
   it('repeat dataset has correct size', async () => {
@@ -669,7 +669,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
     const ds = tfd.generator(func).repeat(3);
-    expect(ds.size).toBeUndefined();
+    expect(ds.size).toBeNull();
   });
 
   it('take dataset has correct size', async () => {
@@ -687,7 +687,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
     const ds = tfd.generator(func).take(3);
-    expect(ds.size).toBeUndefined();
+    expect(ds.size).toBeNull();
   });
 
   it('take dataset with infinity elements has correct size', async () => {
@@ -710,7 +710,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
     const ds = tfd.generator(func).skip(3);
-    expect(ds.size).toBeUndefined();
+    expect(ds.size).toBeNull();
   });
 
   it('skip dataset with infinity elements has infinity size', async () => {
@@ -733,12 +733,48 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
     const ds = tfd.generator(func).batch(2);
-    expect(ds.size).toBeUndefined();
+    expect(ds.size).toBeNull();
   });
 
   it('batch dataset with infinity elements has infinity size', async () => {
     const ds = tfd.array([1, 2, 3, 4, 5]).repeat().batch(2);
     expect(ds.size).toEqual(Infinity);
+  });
+
+  it('map dataset preserves regular size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).map(e => e + 1);
+    expect(ds.size).toEqual(5);
+  });
+
+  it('map dataset preserves infinity size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).repeat().map(e => e + 1);
+    expect(ds.size).toEqual(Infinity);
+  });
+
+  it('map dataset preserves null size', async () => {
+    let i = -1;
+    const func = () =>
+        ++i < 7 ? {value: i, done: false} : {value: null, done: true};
+    const ds = tfd.generator(func).map(e => e + 1);
+    expect(ds.size).toBeNull();
+  });
+
+  it('filter dataset preserves infinity size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).repeat().filter(e => e % 2 === 0);
+    expect(ds.size).toEqual(Infinity);
+  });
+
+  it('filter dataset with regular size has null size', async () => {
+    const ds = tfd.array([1, 2, 3, 4, 5]).filter(e => e % 2 === 0);
+    expect(ds.size).toBeNull();
+  });
+
+  it('filter dataset with null size has null size', async () => {
+    let i = -1;
+    const func = () =>
+        ++i < 7 ? {value: i, done: false} : {value: null, done: true};
+    const ds = tfd.generator(func).filter(e => e % 2 === 0);
+    expect(ds.size).toBeNull();
   });
 
   it('zipping an array of datasets with primitive elements has correct size',

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -223,20 +223,18 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
      async done => {
        try {
          let count = 0;
-         const a =
-             tfd.generator(async () => {
-               if (count > 2) {
-                 throw new Error('propagate me!');
-                }
-                return {value: count++, done: false};
-              });
+         const a = tfd.generator(async () => {
+           if (count > 2) {
+             throw new Error('propagate me!');
+           }
+           return {value: count++, done: false};
+         });
          const b = tfd.array([3, 4, 5, 6]);
          // tslint:disable-next-line:no-any
          await (await tfd.zip([a, b]).iterator()).collect(1000, 0);
          done.fail();
        } catch (e) {
-         expect(e.message).toEqual(
-             'propagate me!');
+         expect(e.message).toEqual('propagate me!');
          done();
        }
      });
@@ -553,43 +551,45 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
   });
 
   it('clone tensors when returning iterator of a dataset generated from ' +
-  'existing tensors', async () => {
-    expect(tf.memory().numTensors).toEqual(0);
-    const a = tf.ones([2, 1]);
-    const b = tf.ones([2, 1]);
-    expect(tf.memory().numTensors).toEqual(2);
-    const ds = tfd.array([a, b]);
-    // Pre-existing tensors are not cloned during dataset creation.
-    expect(tf.memory().numTensors).toEqual(2);
+         'existing tensors',
+     async () => {
+       expect(tf.memory().numTensors).toEqual(0);
+       const a = tf.ones([2, 1]);
+       const b = tf.ones([2, 1]);
+       expect(tf.memory().numTensors).toEqual(2);
+       const ds = tfd.array([a, b]);
+       // Pre-existing tensors are not cloned during dataset creation.
+       expect(tf.memory().numTensors).toEqual(2);
 
-    let count = 0;
-    // ds.forEach() automatically disposes incoming Tensors after processing
-    // them.
-    await ds.forEach(elem => {
-      count++;
-      expect(elem.isDisposed).toBeFalsy();
-    });
-    expect(count).toEqual(2);
-    // Cloned tensors are disposed after traverse, while original tensors stay.
-    expect(tf.memory().numTensors).toEqual(2);
+       let count = 0;
+       // ds.forEach() automatically disposes incoming Tensors after processing
+       // them.
+       await ds.forEach(elem => {
+         count++;
+         expect(elem.isDisposed).toBeFalsy();
+       });
+       expect(count).toEqual(2);
+       // Cloned tensors are disposed after traverse, while original tensors
+       // stay.
+       expect(tf.memory().numTensors).toEqual(2);
 
-    await ds.forEach(elem => {
-      count++;
-      expect(elem.isDisposed).toBeFalsy();
-    });
-    expect(count).toEqual(4);
-    expect(tf.memory().numTensors).toEqual(2);
+       await ds.forEach(elem => {
+         count++;
+         expect(elem.isDisposed).toBeFalsy();
+       });
+       expect(count).toEqual(4);
+       expect(tf.memory().numTensors).toEqual(2);
 
-    await ds.forEach(elem => {
-      count++;
-      expect(elem.isDisposed).toBeFalsy();
-    });
-    expect(count).toEqual(6);
-    expect(tf.memory().numTensors).toEqual(2);
+       await ds.forEach(elem => {
+         count++;
+         expect(elem.isDisposed).toBeFalsy();
+       });
+       expect(count).toEqual(6);
+       expect(tf.memory().numTensors).toEqual(2);
 
-    expect(a.isDisposed).toBeFalsy();
-    expect(b.isDisposed).toBeFalsy();
-  });
+       expect(a.isDisposed).toBeFalsy();
+       expect(b.isDisposed).toBeFalsy();
+     });
 
   it('traverse dataset from tensors without leaking Tensors', async () => {
     expect(tf.memory().numTensors).toEqual(0);
@@ -629,5 +629,15 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
 
     expect(a.isDisposed).toBeFalsy();
     expect(b.isDisposed).toBeFalsy();
+  });
+
+  it('can get correct size of dataset from objects array', async () => {
+    const a = tfd.array([{'item': 1}, {'item': 2}, {'item': 3}]);
+    expect(a.getSize()).toEqual(3);
+  });
+
+  it('can get correct size of dataset from number array', async () => {
+    const a = tfd.array([1, 2, 3, 4, 5]);
+    expect(a.getSize()).toEqual(5);
   });
 });


### PR DESCRIPTION
Add size property for dataset class. 

1) Default value is `undefined` representing dataset might be exhausted randomly.
2) `tf.data.array()` will set dataset size with `items.length`
3) `.batch()`, `.skip()`, `.take()`, `.concat()`, `.repeat()`, `tf.data.zip()` will set size accordingly.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/126)
<!-- Reviewable:end -->
