### PR TITLE
Make tf.data.generator takes a function*, or a function that returns iterators

### DIFF
--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -223,7 +223,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
      async done => {
        try {
          let count = 0;
-         const a = tfd.function(async () => {
+         const a = tfd.func(async () => {
            if (count > 2) {
              throw new Error('propagate me!');
            }

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -650,7 +650,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     let i = -1;
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
-    const ds = tfd.generator(func);
+    const ds = tfd.func(func);
     expect(ds.size).toBeNull();
   });
 
@@ -668,7 +668,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     let i = -1;
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
-    const ds = tfd.generator(func).repeat(3);
+    const ds = tfd.func(func).repeat(3);
     expect(ds.size).toBeNull();
   });
 
@@ -686,7 +686,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     let i = -1;
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
-    const ds = tfd.generator(func).take(3);
+    const ds = tfd.func(func).take(3);
     expect(ds.size).toBeNull();
   });
 
@@ -709,7 +709,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     let i = -1;
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
-    const ds = tfd.generator(func).skip(3);
+    const ds = tfd.func(func).skip(3);
     expect(ds.size).toBeNull();
   });
 
@@ -732,7 +732,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     let i = -1;
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
-    const ds = tfd.generator(func).batch(2);
+    const ds = tfd.func(func).batch(2);
     expect(ds.size).toBeNull();
   });
 
@@ -755,7 +755,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     let i = -1;
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
-    const ds = tfd.generator(func).map(e => e + 1);
+    const ds = tfd.func(func).map(e => e + 1);
     expect(ds.size).toBeNull();
   });
 
@@ -773,7 +773,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
     let i = -1;
     const func = () =>
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
-    const ds = tfd.generator(func).filter(e => e % 2 === 0);
+    const ds = tfd.func(func).filter(e => e % 2 === 0);
     expect(ds.size).toBeNull();
   });
 

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -223,20 +223,18 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
      async done => {
        try {
          let count = 0;
-         const a =
-             tfd.generator(async () => {
-               if (count > 2) {
-                 throw new Error('propagate me!');
-                }
-                return {value: count++, done: false};
-              });
+         const a = tfd.fromFunction(async () => {
+           if (count > 2) {
+             throw new Error('propagate me!');
+           }
+           return {value: count++, done: false};
+         });
          const b = tfd.array([3, 4, 5, 6]);
          // tslint:disable-next-line:no-any
          await (await tfd.zip([a, b]).iterator()).collect(1000, 0);
          done.fail();
        } catch (e) {
-         expect(e.message).toEqual(
-             'propagate me!');
+         expect(e.message).toEqual('propagate me!');
          done();
        }
      });
@@ -553,43 +551,45 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
   });
 
   it('clone tensors when returning iterator of a dataset generated from ' +
-  'existing tensors', async () => {
-    expect(tf.memory().numTensors).toEqual(0);
-    const a = tf.ones([2, 1]);
-    const b = tf.ones([2, 1]);
-    expect(tf.memory().numTensors).toEqual(2);
-    const ds = tfd.array([a, b]);
-    // Pre-existing tensors are not cloned during dataset creation.
-    expect(tf.memory().numTensors).toEqual(2);
+         'existing tensors',
+     async () => {
+       expect(tf.memory().numTensors).toEqual(0);
+       const a = tf.ones([2, 1]);
+       const b = tf.ones([2, 1]);
+       expect(tf.memory().numTensors).toEqual(2);
+       const ds = tfd.array([a, b]);
+       // Pre-existing tensors are not cloned during dataset creation.
+       expect(tf.memory().numTensors).toEqual(2);
 
-    let count = 0;
-    // ds.forEach() automatically disposes incoming Tensors after processing
-    // them.
-    await ds.forEach(elem => {
-      count++;
-      expect(elem.isDisposed).toBeFalsy();
-    });
-    expect(count).toEqual(2);
-    // Cloned tensors are disposed after traverse, while original tensors stay.
-    expect(tf.memory().numTensors).toEqual(2);
+       let count = 0;
+       // ds.forEach() automatically disposes incoming Tensors after processing
+       // them.
+       await ds.forEach(elem => {
+         count++;
+         expect(elem.isDisposed).toBeFalsy();
+       });
+       expect(count).toEqual(2);
+       // Cloned tensors are disposed after traverse, while original tensors
+       // stay.
+       expect(tf.memory().numTensors).toEqual(2);
 
-    await ds.forEach(elem => {
-      count++;
-      expect(elem.isDisposed).toBeFalsy();
-    });
-    expect(count).toEqual(4);
-    expect(tf.memory().numTensors).toEqual(2);
+       await ds.forEach(elem => {
+         count++;
+         expect(elem.isDisposed).toBeFalsy();
+       });
+       expect(count).toEqual(4);
+       expect(tf.memory().numTensors).toEqual(2);
 
-    await ds.forEach(elem => {
-      count++;
-      expect(elem.isDisposed).toBeFalsy();
-    });
-    expect(count).toEqual(6);
-    expect(tf.memory().numTensors).toEqual(2);
+       await ds.forEach(elem => {
+         count++;
+         expect(elem.isDisposed).toBeFalsy();
+       });
+       expect(count).toEqual(6);
+       expect(tf.memory().numTensors).toEqual(2);
 
-    expect(a.isDisposed).toBeFalsy();
-    expect(b.isDisposed).toBeFalsy();
-  });
+       expect(a.isDisposed).toBeFalsy();
+       expect(b.isDisposed).toBeFalsy();
+     });
 
   it('traverse dataset from tensors without leaking Tensors', async () => {
     expect(tf.memory().numTensors).toEqual(0);

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -223,7 +223,7 @@ describeWithFlags('Dataset', tf.test_util.CPU_ENVS, () => {
      async done => {
        try {
          let count = 0;
-         const a = tfd.fromFunction(async () => {
+         const a = tfd.function(async () => {
            if (count > 2) {
              throw new Error('propagate me!');
            }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@
 export {array, Dataset, zip} from './dataset';
 export {CSVDataset} from './datasets/csv_dataset';
 export {TextLineDataset} from './datasets/text_line_dataset';
-export {csv, fromFunction, generator} from './readers';
+export {csv, func as function, generator} from './readers';
 export {FileDataSource} from './sources/file_data_source';
 export {URLDataSource} from './sources/url_data_source';
 export {ColumnConfig, DataElement} from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@
 export {array, Dataset, zip} from './dataset';
 export {CSVDataset} from './datasets/csv_dataset';
 export {TextLineDataset} from './datasets/text_line_dataset';
-export {csv, generator} from './readers';
+export {csv, fromFunction, generator} from './readers';
 export {FileDataSource} from './sources/file_data_source';
 export {URLDataSource} from './sources/url_data_source';
 export {ColumnConfig, DataElement} from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@
 export {array, Dataset, zip} from './dataset';
 export {CSVDataset} from './datasets/csv_dataset';
 export {TextLineDataset} from './datasets/text_line_dataset';
-export {csv, func as function, generator} from './readers';
+export {csv, func, generator} from './readers';
 export {FileDataSource} from './sources/file_data_source';
 export {URLDataSource} from './sources/url_data_source';
 export {ColumnConfig, DataElement} from './types';

--- a/src/readers.ts
+++ b/src/readers.ts
@@ -185,7 +185,7 @@ export function func<T extends DataElement>(
  *  }
  */
 export function generator<T extends DataElement>(
-    generator: () => Iterator<T>): Dataset<T> {
+    generator: () => (Iterator<T>|Promise<Iterator<T>>)): Dataset<T> {
   return datasetFromIteratorFn(
-    async () => iteratorFromFunction(generator().next));
+    async () => iteratorFromFunction((await generator()).next));
 }

--- a/src/readers.ts
+++ b/src/readers.ts
@@ -128,11 +128,10 @@ export function func<T extends DataElement>(
 
 /**
  * Create a `Dataset` that produces each element from provided JavaScript
- * generator or iterator.
+ * generator, which is a function*, or a function that returns iterators.
  *
- * Provided iterator should have `.next()` function that returns element in
- * format of `{value: DataElement, done:boolean}`. Provided generator should be
- * a function which returns a iterator.
+ * The returned iterator should have `.next()` function that returns element in
+ * format of `{value: DataElement, done:boolean}`.
  *
  * Example of creating a dataset from an iterator factory:
  * ```js

--- a/src/readers.ts
+++ b/src/readers.ts
@@ -114,7 +114,7 @@ export function csv(source: string, csvConfig: CSVConfig = {}): CSVDataset {
  * let i = -1;
  * const func = () =>
  *    ++i < 5 ? {value: i, done: false} : {value: null, done: true};
- * const ds = tf.data.generator(func);
+ * const ds = tf.data.fromFunction(func);
  * await ds.forEach(e => console.log(e));
  * ```
  *
@@ -145,9 +145,9 @@ export function fromFunction<T extends DataElement>(
  * Example of generating a dataset from iterator:
  * ```js
  * function makeIterator() {
- *  let iterationCount = 0;
+ *   let iterationCount = 0;
  *
- *  const iterator = {
+ *   const iterator = {
  *     next: () => {
  *       let result;
  *       if (iterationCount <= 10) {
@@ -161,7 +161,8 @@ export function fromFunction<T extends DataElement>(
  *   return iterator;
  * }
  *
- * const ds = tfd.generator(makeIterator());
+ * const iter = makeIterator();
+ * const ds = tfd.generator(iter);
  * ds.forEach(e => console.log(e));
  * ```
  *

--- a/src/readers.ts
+++ b/src/readers.ts
@@ -128,7 +128,8 @@ export function func<T extends DataElement>(
 
 /**
  * Create a `Dataset` that produces each element from provided JavaScript
- * generator, which is a function*, or a function that returns iterators.
+ * generator, which is a function* (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_functions),
+ * or a function that returns an iterator(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_functions).
  *
  * The returned iterator should have `.next()` function that returns element in
  * format of `{value: DataElement, done:boolean}`.

--- a/src/readers_test.ts
+++ b/src/readers_test.ts
@@ -110,8 +110,8 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
     async function waitAndCreateCount() {
       return new Promise(resolve => {
         setTimeout(() => {
-          resolve(3)
-        }, 1000)
+          resolve(3);
+        }, 1000);
       });
     }
     async function makeIterator() {
@@ -128,7 +128,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
           }
         };
         return iterator;
-    };
+    }
     const ds = tfd.generator(makeIterator);
     const result = await ds.toArray();
     expect(result).toEqual([3, 4, 5]);

--- a/src/readers_test.ts
+++ b/src/readers_test.ts
@@ -17,14 +17,14 @@
 
 import * as tf from '@tensorflow/tfjs-core';
 import {describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
-import {func, generator} from './readers';
+import *as tfd from './readers';
 
 describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
   it('generate dataset from function', async () => {
     let i = -1;
     const f = () =>
         ++i < 5 ? {value: i, done: false} : {value: null, done: true};
-    const ds = func(f);
+    const ds = tfd.func(f);
     const result = await ds.toArray();
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
@@ -39,7 +39,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
         yield x;
       }
     }
-    const ds = generator(dataGenerator);
+    const ds = tfd.generator(dataGenerator);
     const result = await ds.toArray();
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
@@ -54,7 +54,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
         yield x;
       }
     }
-    const ds = generator(dataGenerator);
+    const ds = tfd.generator(dataGenerator);
     const result1 = await ds.toArray();
     expect(result1).toEqual([0, 1, 2, 3, 4]);
     const result2 = await ds.toArray();
@@ -77,7 +77,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       };
       return iterator;
     }
-    const ds = generator(makeIterator);
+    const ds = tfd.generator(makeIterator);
     const result = await ds.toArray();
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
@@ -99,7 +99,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       };
       return iterator;
     }
-    const ds = generator(makeIterator);
+    const ds = tfd.generator(makeIterator);
     const result1 = await ds.toArray();
     expect(result1).toEqual([0, 1, 2, 3, 4]);
     const result2 = await ds.toArray();

--- a/src/readers_test.ts
+++ b/src/readers_test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+import {describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
+import {fromFunction, generator} from './readers';
+
+describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
+  it('generate dataset from function', async () => {
+    let i = -1;
+    const func = () =>
+        ++i < 5 ? {value: i, done: false} : {value: null, done: true};
+    const ds = fromFunction(func);
+    const result = await ds.toArray();
+    expect(result).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('generate dataset from JavaScript generator', async () => {
+    function* dataGenerator() {
+      const numElements = 5;
+      let index = 0;
+      while (index < numElements) {
+        const x = index;
+        index++;
+        yield x;
+      }
+    }
+    const ds = generator(dataGenerator);
+    const result = await ds.toArray();
+    expect(result).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('generate dataset from JavaScript iterator', async () => {
+    function makeIterator() {
+      let iterationCount = 0;
+
+      const iterator = {
+        next: () => {
+          let result;
+          if (iterationCount < 5) {
+            result = {value: iterationCount, done: false};
+            iterationCount++;
+            return result;
+          }
+          return {value: iterationCount, done: true};
+        }
+      };
+      return iterator;
+    }
+    const iter = makeIterator();
+    const ds = generator(iter);
+    const result = await ds.toArray();
+    expect(result).toEqual([0, 1, 2, 3, 4]);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,18 +136,3 @@ export interface CSVConfig {
    */
   delimiter?: string;
 }
-
-export type JavascriptGenerator<T extends DataElement> = () => {
-  next: () => {
-    value: T;
-    done: boolean;
-  }
-};
-
-export type JavascriptIterator<T extends DataElement> = {
-  next:
-      () => {
-        value: T;
-        done: boolean;
-      }
-};

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,6 @@
 
 import {DataType} from '@tensorflow/tfjs-core';
 import {TensorContainer, TensorContainerArray, TensorContainerObject} from '@tensorflow/tfjs-core/dist/tensor_types';
-
 import {Dataset} from './dataset';
 import {LazyIterator} from './iterators/lazy_iterator';
 
@@ -137,3 +136,18 @@ export interface CSVConfig {
    */
   delimiter?: string;
 }
+
+export type JavascriptGenerator<T extends DataElement> = () => {
+  next: () => {
+    value: T;
+    done: boolean;
+  }
+};
+
+export type JavascriptIterator<T extends DataElement> = {
+  next:
+      () => {
+        value: T;
+        done: boolean;
+      }
+};


### PR DESCRIPTION
Rename current `tf.data.generator()` to `tf.data.func()`, and add real `tf.data.generator()` which takes a function*, or a function that returns iterators

This resolves https://github.com/tensorflow/tfjs/issues/1139#event-2095322581

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/127)
<!-- Reviewable:end -->
