### PR TITLE
Fix parcel issue re 'fs' in browser.  Also update yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "@types/node-fetch": "^2.1.2",
     "node-fetch": "~2.1.2",
     "seedrandom": "~2.4.3"
+  },
+  "browser": {
+    "fs": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4919,10 +4919,10 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
-  integrity sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==
+typescript@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 uglify-es@^3.3.7:
   version "3.3.9"


### PR DESCRIPTION
The current union package 0.15.0, which includes tfjs-data 0.1.7, produces this error when building a dependent project with Parcel:

    node_modules/@tensorflow/tfjs-data/dist/tf-data.esm.js:17:77316: Cannot statically evaluate fs argument

IIUC the `fs` stuff is not available in the browser at all, so we can just exclude it per https://github.com/parcel-bundler/parcel/issues/496.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/130)
<!-- Reviewable:end -->
