### PR TITLE
Fix a bug with tf.data.generator and built-in generators

### DIFF
--- a/src/readers.ts
+++ b/src/readers.ts
@@ -189,7 +189,9 @@ export function func<T extends DataElement>(
  *  }
  */
 export function generator<T extends DataElement>(
-    generator: () => (Iterator<T>| Promise<Iterator<T>>)): Dataset<T> {
-  return datasetFromIteratorFn(
-      async () => iteratorFromFunction((await generator()).next));
+    generator: () => Iterator<T>| Promise<Iterator<T>>): Dataset<T> {
+  return datasetFromIteratorFn(async () => {
+    const gen = await generator();
+    return iteratorFromFunction(() => gen.next());
+  });
 }


### PR DESCRIPTION
Fix a bug where tf.data.generator() doesn't work with built-in generator functions, that is `function*` that didn't go through the transpilation process.

The issue is that .next() losses its `this` context.

Repro:

```html
<script src="tf-data.js"></script>
<script>
  function* f () {
     yield 1;
     yield 2;
  }
  // Error.
  tf.data.generator(f).iterator().next();
</script>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/138)
<!-- Reviewable:end -->
