### PR TITLE
Hint javascript bundler to ignore `fs`, `node-fetch`, and  `string_decoder` in package.browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "seedrandom": "~2.4.3"
   },
   "browser": {
-    "fs": false
+    "fs": false,
+    "node-fetch": false,
+    "string_decoder": false
   }
 }


### PR DESCRIPTION
When using tfjs with angular-cli, it will show `can not resolve 'fs'` error, because tfjs-data is using `fs` in node environment. (original issue: https://github.com/angular/angular-cli/issues/10681)

So hint javascript bundler to ignore `fs`, `node-fetch` and `string_decode` through package.browser field.

This resolves https://github.com/tensorflow/tfjs/issues/1274

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/147)
<!-- Reviewable:end -->
