### PR TITLE
Remove maxItems and prefetch from iterator.collect()/dataset.toArray()

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -498,7 +498,22 @@ export abstract class Dataset<T extends DataElement> {
     if (this.size === Infinity) {
       throw new Error('Can not convert infinity data stream to array.');
     }
-    return (await this.iterator()).collect();
+    return (await this.iterator()).toArray();
+  }
+
+  /**
+   * Collect all elements of this dataset into an array with prefetching 100
+   * elements. This is only used for testing with potential async scheduling,
+   * and generally should be avoided if possible.
+   *
+   * @returns A Promise for an array of elements, which will resolve
+   *   when a new stream has been obtained and fully consumed.
+   */
+  async toArrayForTest() {
+    if (this.size === Infinity) {
+      throw new Error('Can not convert infinity data stream to array.');
+    }
+    return (await this.iterator()).toArrayForTest();
   }
 }
 

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -495,6 +495,9 @@ export abstract class Dataset<T extends DataElement> {
    */
   /** @doc {heading: 'Data', subheading: 'Classes'} */
   async toArray() {
+    if (this.size == Infinity) {
+      throw new Error('Can not convert infinity data stream to array.');
+    }
     return (await this.iterator()).collect();
   }
 }

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -495,7 +495,7 @@ export abstract class Dataset<T extends DataElement> {
    */
   /** @doc {heading: 'Data', subheading: 'Classes'} */
   async toArray() {
-    if (this.size == Infinity) {
+    if (this.size === Infinity) {
       throw new Error('Can not convert infinity data stream to array.');
     }
     return (await this.iterator()).collect();

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -177,7 +177,7 @@ export abstract class Dataset<T extends DataElement> {
       // sum the size of these two datasets.
       size = this.size + dataset.size;
     } else {
-      // If neither of these two datasets has infinity size and any of these two
+      // If neither of these two datasets has infinite size and any of these two
       // datasets' size is null, the new size is null.
       size = null;
     }
@@ -496,22 +496,24 @@ export abstract class Dataset<T extends DataElement> {
   /** @doc {heading: 'Data', subheading: 'Classes'} */
   async toArray() {
     if (this.size === Infinity) {
-      throw new Error('Can not convert infinity data stream to array.');
+      throw new Error('Can not convert infinite data stream to array.');
     }
     return (await this.iterator()).toArray();
   }
 
   /**
-   * Collect all elements of this dataset into an array with prefetching 100
-   * elements. This is only used for testing with potential async scheduling,
-   * and generally should be avoided if possible.
+   * This is useful for testing, because the prefetch changes the order in which
+   * the Promises are resolved along the processing pipeline. This may help
+   * expose bugs where results are dependent on the order of Promise resolution
+   * rather than on the logical order of the stream (i.e., due to hidden mutable
+   * state).
    *
    * @returns A Promise for an array of elements, which will resolve
    *   when a new stream has been obtained and fully consumed.
    */
   async toArrayForTest() {
     if (this.size === Infinity) {
-      throw new Error('Can not convert infinity data stream to array.');
+      throw new Error('Can not convert infinite data stream to array.');
     }
     return (await this.iterator()).toArrayForTest();
   }

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -502,11 +502,12 @@ export abstract class Dataset<T extends DataElement> {
   }
 
   /**
-   * This is useful for testing, because the prefetch changes the order in which
-   * the Promises are resolved along the processing pipeline. This may help
-   * expose bugs where results are dependent on the order of Promise resolution
-   * rather than on the logical order of the stream (i.e., due to hidden mutable
-   * state).
+   * Collect all elements of this dataset into an array with prefetching 100
+   * elements. This is useful for testing, because the prefetch changes the
+   * order in which the Promises are resolved along the processing pipeline.
+   * This may help expose bugs where results are dependent on the order of
+   * Promise resolution rather than on the logical order of the stream (i.e.,
+   * due to hidden mutable state).
    *
    * @returns A Promise for an array of elements, which will resolve
    *   when a new stream has been obtained and fully consumed.

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -199,9 +199,8 @@ describeWithFlags(
         const b = tfd.array([4, 5, 6]);
         const c = tfd.array([7, 8, 9]);
         const d = tfd.array([10, 11, 12]);
-        const result = await tfd.zip({a, abacd: [a, b, {a, c, d}]})
-                           .prefetch(100)
-                           .toArray();
+        const result =
+            await tfd.zip({a, abacd: [a, b, {a, c, d}]}).toArrayForTest();
 
         expect(result).toEqual([
           {a: 1, abacd: [1, 4, {a: 1, c: 7, d: 10}]},
@@ -527,8 +526,7 @@ describeWithFlags(
         const ds = new TestDataset();
         expect(tf.memory().numTensors).toEqual(0);
         await ds.filter(x => ((x['number'] as number) % 2 === 0))
-            .prefetch(100)
-            .toArray();
+            .toArrayForTest();
         // Each element of the test dataset contains 2 Tensors.
         // There were 100 elements, but we filtered out half of them.
         // Thus 50 * 2 = 100 Tensors remain.
@@ -597,9 +595,7 @@ describeWithFlags(
          async () => {
            const ds = new TestDataset();
            expect(tf.memory().numTensors).toEqual(0);
-           await ds.map(x => ({'Tensor2': x['Tensor2']}))
-               .prefetch(100)
-               .toArray();
+           await ds.map(x => ({'Tensor2': x['Tensor2']})).toArrayForTest();
            // Each element of the test dataset contains 2 Tensors.
            // Our map operation retained one of the Tensors and discarded the
            // other. Thus the mapped data contains 100 elements with 1 Tensor
@@ -610,9 +606,7 @@ describeWithFlags(
       it('map does not leak Tensors when inputs are replaced', async () => {
         const ds = new TestDataset();
         expect(tf.memory().numTensors).toEqual(0);
-        await ds.map(x => ({'a': tf.tensor1d([1, 2, 3])}))
-            .prefetch(100)
-            .toArray();
+        await ds.map(x => ({'a': tf.tensor1d([1, 2, 3])})).toArrayForTest();
         // Each element of the test dataset contains 2 Tensors.
         // Our map operation discarded both Tensors and created one new one.
         // Thus the mapped data contains 100 elements with 1 Tensor each.
@@ -742,7 +736,7 @@ describeWithFlags(
         expect(ds.size).toEqual(15);
       });
 
-      it('repeat dataset forever has infinity size', async () => {
+      it('repeat dataset forever has infinite size', async () => {
         const ds = tfd.array([1, 2, 3, 4, 5]).repeat();
         expect(ds.size).toEqual(Infinity);
       });
@@ -773,7 +767,7 @@ describeWithFlags(
         expect(ds.size).toBeNull();
       });
 
-      it('take dataset with infinity elements has correct size', async () => {
+      it('take dataset with infinite elements has correct size', async () => {
         const ds = tfd.array([1, 2, 3, 4, 5]).repeat().take(10);
         expect(ds.size).toEqual(10);
       });
@@ -796,7 +790,7 @@ describeWithFlags(
         expect(ds.size).toBeNull();
       });
 
-      it('skip dataset with infinity elements has infinity size', async () => {
+      it('skip dataset with infinite elements has infinity size', async () => {
         const ds = tfd.array([1, 2, 3, 4, 5]).repeat().skip(10);
         expect(ds.size).toEqual(Infinity);
       });
@@ -820,7 +814,7 @@ describeWithFlags(
         expect(ds.size).toBeNull();
       });
 
-      it('batch dataset with infinity elements has infinity size', async () => {
+      it('batch dataset with infinite elements has infinity size', async () => {
         const ds = tfd.array([1, 2, 3, 4, 5]).repeat().batch(2);
         expect(ds.size).toEqual(Infinity);
       });
@@ -895,7 +889,7 @@ describeWithFlags(
            expect(result.size).toEqual(3);
          });
 
-      it('converting dataset with infinity elements to array throws error',
+      it('converting dataset with infinite elements to array throws error',
          async done => {
            try {
              const ds = tfd.array([1, 2, 3, 4, 5]).repeat();
@@ -904,7 +898,7 @@ describeWithFlags(
              done.fail();
            } catch (e) {
              expect(e.message).toEqual(
-                 'Can not convert infinity data stream to array.');
+                 'Can not convert infinite data stream to array.');
              done();
            }
          });

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -94,7 +94,7 @@ describeWithFlags(
       it('can be concatenated', async () => {
         const a = tfd.array([{'item': 1}, {'item': 2}, {'item': 3}]);
         const b = tfd.array([{'item': 4}, {'item': 5}, {'item': 6}]);
-        const result = await a.concatenate(b).prefetch(100).toArray();
+        const result = await a.concatenate(b).toArrayForTest();
         expect(result).toEqual([
           {'item': 1}, {'item': 2}, {'item': 3}, {'item': 4}, {'item': 5},
           {'item': 6}
@@ -108,7 +108,7 @@ describeWithFlags(
            const b = tfd.array([{'item': 3}, {'item': 4}]);
            const c = tfd.array([{'item': 5}, {'item': 6}]);
            const concatenated = [a, b, c].reduce((a, b) => a.concatenate(b));
-           const result = await concatenated.prefetch(100).toArray();
+           const result = await concatenated.toArrayForTest();
            expect(result).toEqual([
              {'item': 1}, {'item': 2}, {'item': 3}, {'item': 4}, {'item': 5},
              {'item': 6}
@@ -120,7 +120,7 @@ describeWithFlags(
          async () => {
            const a = tfd.array([1, 2, 3]);
            const b = tfd.array([4, 5, 6]);
-           const result = await tfd.zip([a, b]).prefetch(100).toArray();
+           const result = await tfd.zip([a, b]).toArrayForTest();
            expect(result).toEqual([[1, 4], [2, 5], [3, 6]]);
          });
 
@@ -128,7 +128,7 @@ describeWithFlags(
          async () => {
            const a = tfd.array([{a: 1}, {a: 2}, {a: 3}]);
            const b = tfd.array([{b: 4}, {b: 5}, {b: 6}]);
-           const result = await tfd.zip([a, b]).prefetch(100).toArray();
+           const result = await tfd.zip([a, b]).toArrayForTest();
            expect(result).toEqual(
                [[{a: 1}, {b: 4}], [{a: 2}, {b: 5}], [{a: 3}, {b: 6}]]);
          });
@@ -136,7 +136,7 @@ describeWithFlags(
       it('can be created by zipping a dict of datasets', async () => {
         const a = tfd.array([{a: 1}, {a: 2}, {a: 3}]);
         const b = tfd.array([{b: 4}, {b: 5}, {b: 6}]);
-        const result = await tfd.zip({c: a, d: b}).prefetch(100).toArray();
+        const result = await tfd.zip({c: a, d: b}).toArrayForTest();
         expect(result).toEqual([
           {c: {a: 1}, d: {b: 4}}, {c: {a: 2}, d: {b: 5}}, {c: {a: 3}, d: {b: 6}}
         ]);
@@ -148,8 +148,7 @@ describeWithFlags(
            const b = tfd.array([4, 5, 6]);
            const c = tfd.array([7, 8, 9]);
            const d = tfd.array([10, 11, 12]);
-           const result =
-               await tfd.zip({a, bcd: [b, {c, d}]}).prefetch(100).toArray();
+           const result = await tfd.zip({a, bcd: [b, {c, d}]}).toArrayForTest();
 
            expect(result).toEqual([
              {a: 1, bcd: [4, {c: 7, d: 10}]},
@@ -161,7 +160,7 @@ describeWithFlags(
       it('can be created by zipping datasets of different sizes', async () => {
         const a = tfd.array([1, 2]);
         const b = tfd.array([3, 4, 5, 6]);
-        const result = await tfd.zip([a, b]).prefetch(100).toArray();
+        const result = await tfd.zip([a, b]).toArrayForTest();
         expect(result).toEqual([[1, 3], [2, 4]]);
       });
 
@@ -239,7 +238,7 @@ describeWithFlags(
              });
              const b = tfd.array([3, 4, 5, 6]);
              // tslint:disable-next-line:no-any
-             await (await tfd.zip([a, b]).iterator()).collect();
+             await (await tfd.zip([a, b]).iterator()).toArray();
              done.fail();
            } catch (e) {
              expect(e.message).toEqual('propagate me!');
@@ -249,7 +248,7 @@ describeWithFlags(
 
       it('can be repeated a fixed number of times', async () => {
         const a = tfd.array([{'item': 1}, {'item': 2}, {'item': 3}]);
-        const result = await a.repeat(4).prefetch(100).toArray();
+        const result = await a.repeat(4).toArrayForTest();
         expect(result).toEqual([
           {'item': 1},
           {'item': 2},
@@ -268,7 +267,7 @@ describeWithFlags(
 
       it('can be repeated indefinitely', async () => {
         const a = tfd.array([{'item': 1}, {'item': 2}, {'item': 3}]);
-        await a.repeat().take(234).prefetch(100).toArray();
+        await a.repeat().take(234).toArrayForTest();
       });
 
       it('can be repeated with state in a closure', async () => {
@@ -287,12 +286,12 @@ describeWithFlags(
           }
         }
         const a = new CustomDataset();
-        await a.repeat().take(1234).prefetch(100).toArray();
+        await a.repeat().take(1234).toArrayForTest();
       });
 
       it('can collect all items into memory', async () => {
         const ds = new TestDataset();
-        const items = await ds.prefetch(100).toArray();
+        const items = await ds.toArrayForTest();
         expect(items.length).toEqual(100);
         // The test dataset has 100 elements, each containing 2 Tensors.
         expect(tf.memory().numTensors).toEqual(200);
@@ -302,7 +301,7 @@ describeWithFlags(
         const ds = new TestDataset();
         const bds = ds.batch(8);
         const batchIterator = await bds.iterator();
-        const result = await batchIterator.prefetch(100).collect();
+        const result = await batchIterator.toArrayForTest();
 
         expect(result.length).toEqual(13);
         result.slice(0, 12).forEach(batch => {
@@ -356,7 +355,7 @@ describeWithFlags(
            const compareDataset = tfd.zip({complexThenBatch, batchThenComplex});
 
            const result =
-               await (await compareDataset.iterator()).prefetch(100).collect();
+               await (await compareDataset.iterator()).toArrayForTest();
 
            expect(result.length).toEqual(13);
            // tslint:disable-next-line:no-any
@@ -400,7 +399,7 @@ describeWithFlags(
                 })
                 .batch(8);
 
-        const result = await (await dataset.iterator()).prefetch(100).collect();
+        const result = await (await dataset.iterator()).toArrayForTest();
         expect(result.length).toEqual(13);
 
         // tslint:disable-next-line:no-any
@@ -436,7 +435,7 @@ describeWithFlags(
          async done => {
            const dataset = array([[[1, 2], [3]], [[4, 5], [6]]]).batch(2);
            try {
-             await (await dataset.iterator()).collect();
+             await (await dataset.iterator()).toArray();
              done.fail();
            } catch (e) {
              expect(e.message).toEqual(
@@ -451,7 +450,7 @@ describeWithFlags(
         const ds = new TestDataset();
         const bds = ds.batch(8);
         const batchIterator = await bds.iterator();
-        const result = await batchIterator.prefetch(100).collect();
+        const result = await batchIterator.toArrayForTest();
         const lastBatch = result[result.length - 1] as TensorContainerObject;
         expect((lastBatch['number'] as tf.Tensor).shape).toEqual([4]);
         expect((lastBatch['numberArray'] as tf.Tensor).shape).toEqual([4, 3]);
@@ -512,7 +511,7 @@ describeWithFlags(
         try {
           const ds = new TestDataset();
           expect(tf.memory().numTensors).toEqual(0);
-          const result = await ds.skip(15).prefetch(100).toArray();
+          const result = await ds.skip(15).toArrayForTest();
           // The test dataset had 100 elements; we skipped 15; 85 remain.
           expect(result.length).toEqual(85);
           // Each element of the test dataset contains 2 Tensors;
@@ -539,7 +538,7 @@ describeWithFlags(
       it('shuffle does not leak Tensors', async () => {
         const ds = new TestDataset();
         expect(tf.memory().numTensors).toEqual(0);
-        await ds.shuffle(1000).prefetch(100).toArray();
+        await ds.shuffle(1000).toArrayForTest();
         // The shuffle operation emitted all of the tensors.
         expect(tf.memory().numTensors).toEqual(200);
       });
@@ -588,7 +587,7 @@ describeWithFlags(
       it('map does not leak Tensors when none are returned', async () => {
         const ds = new TestDataset();
         expect(tf.memory().numTensors).toEqual(0);
-        await ds.map(x => ({'constant': 1})).prefetch(100).toArray();
+        await ds.map(x => ({'constant': 1})).toArrayForTest();
         // The map operation consumed all of the tensors and emitted none.
         expect(tf.memory().numTensors).toEqual(0);
       });

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -895,4 +895,18 @@ describeWithFlags(
            const result = await tfd.zip({'a': a, 'b': b});
            expect(result.size).toEqual(3);
          });
+
+      it('converting dataset with infinity elements to array throws error',
+         async done => {
+           try {
+             const ds = tfd.array([1, 2, 3, 4, 5]).repeat();
+             expect(ds.size).toEqual(Infinity);
+             await ds.toArray();
+             done.fail();
+           } catch (e) {
+             expect(e.message).toEqual(
+                 'Can not convert infinity data stream to array.');
+             done();
+           }
+         });
     });

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -236,7 +236,10 @@ describeWithFlags(
                return {value: count++, done: false};
              });
              const b = tfd.array([3, 4, 5, 6]);
-             // tslint:disable-next-line:no-any
+             // Using toArray() rather than toArrayForTest().  The prefetch in
+             // the latter, in combination with expecting an exception, causes
+             // unrelated tests to fail (See
+             // https://github.com/tensorflow/tfjs/issues/1330.
              await (await tfd.zip([a, b]).iterator()).toArray();
              done.fail();
            } catch (e) {
@@ -434,6 +437,10 @@ describeWithFlags(
          async done => {
            const dataset = array([[[1, 2], [3]], [[4, 5], [6]]]).batch(2);
            try {
+             // Using toArray() rather than toArrayForTest().  The prefetch in
+             // the latter, in combination with expecting an exception, causes
+             // unrelated tests to fail (See
+             // https://github.com/tensorflow/tfjs/issues/1330.
              await (await dataset.iterator()).toArray();
              done.fail();
            } catch (e) {
@@ -894,6 +901,10 @@ describeWithFlags(
            try {
              const ds = tfd.array([1, 2, 3, 4, 5]).repeat();
              expect(ds.size).toEqual(Infinity);
+             // Using toArray() rather than toArrayForTest().  The prefetch in
+             // the latter, in combination with expecting an exception, causes
+             // unrelated tests to fail (See
+             // https://github.com/tensorflow/tfjs/issues/1330.
              await ds.toArray();
              done.fail();
            } catch (e) {

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -901,11 +901,7 @@ describeWithFlags(
            try {
              const ds = tfd.array([1, 2, 3, 4, 5]).repeat();
              expect(ds.size).toEqual(Infinity);
-             // Using toArray() rather than toArrayForTest().  The prefetch in
-             // the latter, in combination with expecting an exception, causes
-             // unrelated tests to fail (See
-             // https://github.com/tensorflow/tfjs/issues/1330.
-             await ds.toArray();
+             await ds.toArrayForTest();
              done.fail();
            } catch (e) {
              expect(e.message).toEqual(

--- a/src/datasets/csv_dataset_test.ts
+++ b/src/datasets/csv_dataset_test.ts
@@ -96,7 +96,7 @@ describe('CSVDataset', () => {
        expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
 
        const iter = await dataset.iterator();
-       const result = await iter.prefetch(100).collect();
+       const result = await iter.toArrayForTest();
 
        expect(result).toEqual([
          {'foo': 'ab', 'bar': 'cd', 'baz': 'ef'},
@@ -115,7 +115,7 @@ describe('CSVDataset', () => {
 
     expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
     const iter = await dataset.iterator();
-    const result = await iter.prefetch(100).collect();
+    const result = await iter.toArrayForTest();
 
     expect(result).toEqual([
       {'foo': 'ab', 'bar': 'cd', 'baz': 'ef'},
@@ -166,7 +166,7 @@ describe('CSVDataset', () => {
     const dataset = new CSVDataset(source);
     expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
     const iter = await dataset.iterator();
-    const result = await iter.prefetch(100).collect();
+    const result = await iter.toArrayForTest();
 
     expect(result).toEqual([
       {'foo': 'ab', 'bar': 'cd', 'baz': 'ef'},
@@ -206,7 +206,7 @@ describe('CSVDataset', () => {
       });
       expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
       const iter = await dataset.iterator();
-      await iter.prefetch(100).collect();
+      await iter.toArrayForTest();
       done.fail();
     } catch (error) {
       expect(error.message)
@@ -225,7 +225,7 @@ describe('CSVDataset', () => {
 
     expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
     const iter = await dataset.iterator();
-    const result = await iter.prefetch(100).collect();
+    const result = await iter.toArrayForTest();
 
     expect(result).toEqual([
       {'foo': 'ab', 'bar': 'cd', 'baz': 'ef'},
@@ -243,7 +243,7 @@ describe('CSVDataset', () => {
     const dataset = new CSVDataset(source, {delimiter: ';'});
     expect(await dataset.columnNames()).toEqual(['A', 'B', 'C']);
     const iter = await dataset.iterator();
-    const result = await iter.prefetch(100).collect();
+    const result = await iter.toArrayForTest();
 
     expect(result[0]).toEqual({A: 1, B: 2, C: 3});
     expect(result[1]).toEqual({A: 2, B: 2, C: 3});
@@ -265,7 +265,7 @@ describe('CSVDataset', () => {
        });
        expect(await dataset.columnNames()).toEqual(['A', 'B', 'C', 'D']);
        const iter = await dataset.iterator();
-       const result = await iter.prefetch(100).collect();
+       const result = await iter.toArrayForTest();
 
        expect(result).toEqual([
          {'A': 1, 'B': 1, 'C': 3, 'D': 1}, {'A': 2, 'B': 0, 'C': 2, 'D': 0},
@@ -283,7 +283,7 @@ describe('CSVDataset', () => {
 
     expect(await dataset.columnNames()).toEqual(['bar', 'foo']);
     const iter = await dataset.iterator();
-    const result = await iter.prefetch(100).collect();
+    const result = await iter.toArrayForTest();
 
     expect(result).toEqual([
       {'bar': 'cd', 'foo': 'ab'},
@@ -316,7 +316,7 @@ describe('CSVDataset', () => {
     const dataset = new CSVDataset(source, {columnNames: ['a', 'b', 'c']});
     expect(await dataset.columnNames()).toEqual(['a', 'b', 'c']);
     const iter = await dataset.iterator();
-    const result = await iter.prefetch(100).collect();
+    const result = await iter.toArrayForTest();
 
     expect(result).toEqual([
       {'a': 'ab', 'b': 'cd', 'c': 'ef'},
@@ -336,7 +336,7 @@ describe('CSVDataset', () => {
           new CSVDataset(source, {columnConfigs: {'baz': {isLabel: true}}});
       expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
       const iter = await dataset.iterator();
-      await iter.collect();
+      await iter.toArray();
       done.fail();
     } catch (e) {
       expect(e.message).toEqual(
@@ -351,7 +351,7 @@ describe('CSVDataset', () => {
         new CSVDataset(source, {columnConfigs: {'C': {isLabel: true}}});
     expect(await dataset.columnNames()).toEqual(['A', 'B', 'C']);
     const iter = await dataset.iterator();
-    const result = await iter.prefetch(100).collect();
+    const result = await iter.toArrayForTest();
 
     expect(result).toEqual([
       {xs: {'A': 1, 'B': 2}, ys: {'C': 3}},
@@ -368,7 +368,7 @@ describe('CSVDataset', () => {
     const dataset = new CSVDataset(source);
     expect(await dataset.columnNames()).toEqual(['A', 'B', 'C']);
     const iter = await dataset.iterator();
-    const result = await iter.prefetch(100).collect();
+    const result = await iter.toArrayForTest();
 
     expect(result).toEqual([
       {'A': 1, 'B': 2, 'C': 3}, {'A': 2, 'B': 2, 'C': 3},

--- a/src/datasets/csv_dataset_test.ts
+++ b/src/datasets/csv_dataset_test.ts
@@ -336,6 +336,10 @@ describe('CSVDataset', () => {
           new CSVDataset(source, {columnConfigs: {'baz': {isLabel: true}}});
       expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
       const iter = await dataset.iterator();
+      // Using toArray() rather than toArrayForTest().  The prefetch in
+      // the latter, in combination with expecting an exception, causes
+      // unrelated tests to fail (See
+      // https://github.com/tensorflow/tfjs/issues/1330.
       await iter.toArray();
       done.fail();
     } catch (e) {

--- a/src/datasets/csv_dataset_test.ts
+++ b/src/datasets/csv_dataset_test.ts
@@ -96,7 +96,7 @@ describe('CSVDataset', () => {
        expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
 
        const iter = await dataset.iterator();
-       const result = await iter.collect();
+       const result = await iter.prefetch(100).collect();
 
        expect(result).toEqual([
          {'foo': 'ab', 'bar': 'cd', 'baz': 'ef'},
@@ -115,7 +115,7 @@ describe('CSVDataset', () => {
 
     expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
     const iter = await dataset.iterator();
-    const result = await iter.collect();
+    const result = await iter.prefetch(100).collect();
 
     expect(result).toEqual([
       {'foo': 'ab', 'bar': 'cd', 'baz': 'ef'},
@@ -166,7 +166,7 @@ describe('CSVDataset', () => {
     const dataset = new CSVDataset(source);
     expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
     const iter = await dataset.iterator();
-    const result = await iter.collect();
+    const result = await iter.prefetch(100).collect();
 
     expect(result).toEqual([
       {'foo': 'ab', 'bar': 'cd', 'baz': 'ef'},
@@ -206,7 +206,7 @@ describe('CSVDataset', () => {
       });
       expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
       const iter = await dataset.iterator();
-      await iter.collect();
+      await iter.prefetch(100).collect();
       done.fail();
     } catch (error) {
       expect(error.message)
@@ -225,7 +225,7 @@ describe('CSVDataset', () => {
 
     expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
     const iter = await dataset.iterator();
-    const result = await iter.collect();
+    const result = await iter.prefetch(100).collect();
 
     expect(result).toEqual([
       {'foo': 'ab', 'bar': 'cd', 'baz': 'ef'},
@@ -243,7 +243,7 @@ describe('CSVDataset', () => {
     const dataset = new CSVDataset(source, {delimiter: ';'});
     expect(await dataset.columnNames()).toEqual(['A', 'B', 'C']);
     const iter = await dataset.iterator();
-    const result = await iter.collect();
+    const result = await iter.prefetch(100).collect();
 
     expect(result[0]).toEqual({A: 1, B: 2, C: 3});
     expect(result[1]).toEqual({A: 2, B: 2, C: 3});
@@ -265,7 +265,7 @@ describe('CSVDataset', () => {
        });
        expect(await dataset.columnNames()).toEqual(['A', 'B', 'C', 'D']);
        const iter = await dataset.iterator();
-       const result = await iter.collect();
+       const result = await iter.prefetch(100).collect();
 
        expect(result).toEqual([
          {'A': 1, 'B': 1, 'C': 3, 'D': 1}, {'A': 2, 'B': 0, 'C': 2, 'D': 0},
@@ -283,7 +283,7 @@ describe('CSVDataset', () => {
 
     expect(await dataset.columnNames()).toEqual(['bar', 'foo']);
     const iter = await dataset.iterator();
-    const result = await iter.collect();
+    const result = await iter.prefetch(100).collect();
 
     expect(result).toEqual([
       {'bar': 'cd', 'foo': 'ab'},
@@ -316,7 +316,7 @@ describe('CSVDataset', () => {
     const dataset = new CSVDataset(source, {columnNames: ['a', 'b', 'c']});
     expect(await dataset.columnNames()).toEqual(['a', 'b', 'c']);
     const iter = await dataset.iterator();
-    const result = await iter.collect();
+    const result = await iter.prefetch(100).collect();
 
     expect(result).toEqual([
       {'a': 'ab', 'b': 'cd', 'c': 'ef'},
@@ -336,7 +336,7 @@ describe('CSVDataset', () => {
           new CSVDataset(source, {columnConfigs: {'baz': {isLabel: true}}});
       expect(await dataset.columnNames()).toEqual(['foo', 'bar', 'baz']);
       const iter = await dataset.iterator();
-      await iter.collect(1000, 0);
+      await iter.collect();
       done.fail();
     } catch (e) {
       expect(e.message).toEqual(
@@ -351,7 +351,7 @@ describe('CSVDataset', () => {
         new CSVDataset(source, {columnConfigs: {'C': {isLabel: true}}});
     expect(await dataset.columnNames()).toEqual(['A', 'B', 'C']);
     const iter = await dataset.iterator();
-    const result = await iter.collect();
+    const result = await iter.prefetch(100).collect();
 
     expect(result).toEqual([
       {xs: {'A': 1, 'B': 2}, ys: {'C': 3}},
@@ -368,7 +368,7 @@ describe('CSVDataset', () => {
     const dataset = new CSVDataset(source);
     expect(await dataset.columnNames()).toEqual(['A', 'B', 'C']);
     const iter = await dataset.iterator();
-    const result = await iter.collect();
+    const result = await iter.prefetch(100).collect();
 
     expect(result).toEqual([
       {'A': 1, 'B': 2, 'C': 3}, {'A': 2, 'B': 2, 'C': 3},

--- a/src/datasets/text_line_dataset_test.ts
+++ b/src/datasets/text_line_dataset_test.ts
@@ -32,7 +32,7 @@ describe('TextLineDataset', () => {
        const source = new FileDataSource(testBlob, {chunkSize: 10});
        const dataset = new TextLineDataset(source);
        const iter = await dataset.iterator();
-       const result = await iter.prefetch(100).collect();
+       const result = await iter.toArrayForTest();
 
        expect(result).toEqual([
          'ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ',

--- a/src/datasets/text_line_dataset_test.ts
+++ b/src/datasets/text_line_dataset_test.ts
@@ -32,7 +32,7 @@ describe('TextLineDataset', () => {
        const source = new FileDataSource(testBlob, {chunkSize: 10});
        const dataset = new TextLineDataset(source);
        const iter = await dataset.iterator();
-       const result = await iter.collect();
+       const result = await iter.prefetch(100).collect();
 
        expect(result).toEqual([
          'ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ',

--- a/src/iterators/byte_chunk_iterator_test.ts
+++ b/src/iterators/byte_chunk_iterator_test.ts
@@ -33,7 +33,7 @@ describe('ByteChunkIterator.decodeUTF8()', () => {
         .toEqual(323);
     const utf8Iterator = byteChunkIterator.decodeUTF8();
 
-    const result = await utf8Iterator.prefetch(100).collect();
+    const result = await utf8Iterator.toArrayForTest();
     // The test string is 109 characters long; its UTF8 encoding is 323
     // bytes. We read it in chunks of 50 bytes, so there were 7 chunks of
     // bytes. The UTF decoder slightly adjusted the boundaries between the

--- a/src/iterators/byte_chunk_iterator_test.ts
+++ b/src/iterators/byte_chunk_iterator_test.ts
@@ -33,7 +33,7 @@ describe('ByteChunkIterator.decodeUTF8()', () => {
         .toEqual(323);
     const utf8Iterator = byteChunkIterator.decodeUTF8();
 
-    const result = await utf8Iterator.collect();
+    const result = await utf8Iterator.prefetch(100).collect();
     // The test string is 109 characters long; its UTF8 encoding is 323
     // bytes. We read it in chunks of 50 bytes, so there were 7 chunks of
     // bytes. The UTF decoder slightly adjusted the boundaries between the

--- a/src/iterators/chained_iterator_test.ts
+++ b/src/iterators/chained_iterator_test.ts
@@ -34,7 +34,7 @@ describe('ChainedIterator', () => {
       }
     }
 
-    const result = await chainedIterator.collect();
+    const result = await chainedIterator.prefetch(100).collect();
     expect(result).toEqual(expectedResult);
   });
   it('produces multiple underlying streams as expected', async () => {
@@ -51,7 +51,7 @@ describe('ChainedIterator', () => {
       }
     }
 
-    const result = await chainedIterator.collect();
+    const result = await chainedIterator.prefetch(100).collect();
     expect(result).toEqual(expectedResult);
   });
 });

--- a/src/iterators/chained_iterator_test.ts
+++ b/src/iterators/chained_iterator_test.ts
@@ -34,7 +34,7 @@ describe('ChainedIterator', () => {
       }
     }
 
-    const result = await chainedIterator.prefetch(100).collect();
+    const result = await chainedIterator.toArrayForTest();
     expect(result).toEqual(expectedResult);
   });
   it('produces multiple underlying streams as expected', async () => {
@@ -51,7 +51,7 @@ describe('ChainedIterator', () => {
       }
     }
 
-    const result = await chainedIterator.prefetch(100).collect();
+    const result = await chainedIterator.toArrayForTest();
     expect(result).toEqual(expectedResult);
   });
 });

--- a/src/iterators/file_chunk_iterator_test.ts
+++ b/src/iterators/file_chunk_iterator_test.ts
@@ -30,7 +30,7 @@ const testData = ENV.get('IS_BROWSER') ?
 describe('FileChunkIterator', () => {
   it('Reads the entire file and then closes the stream', async () => {
     const readIterator = new FileChunkIterator(testData, {chunkSize: 10});
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result.length).toEqual(6);
     const totalBytes = result.map(x => x.length).reduce((a, b) => a + b);
     expect(totalBytes).toEqual(55);
@@ -38,7 +38,7 @@ describe('FileChunkIterator', () => {
 
   it('Reads chunks in order', async () => {
     const readIterator = new FileChunkIterator(testData, {chunkSize: 10});
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result[0][0]).toEqual(0);
     expect(result[1][0]).toEqual(10);
     expect(result[2][0]).toEqual(20);
@@ -49,7 +49,7 @@ describe('FileChunkIterator', () => {
 
   it('Reads chunks of expected sizes', async () => {
     const readIterator = new FileChunkIterator(testData, {chunkSize: 10});
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result[0].length).toEqual(10);
     expect(result[1].length).toEqual(10);
     expect(result[2].length).toEqual(10);

--- a/src/iterators/file_chunk_iterator_test.ts
+++ b/src/iterators/file_chunk_iterator_test.ts
@@ -30,7 +30,7 @@ const testData = ENV.get('IS_BROWSER') ?
 describe('FileChunkIterator', () => {
   it('Reads the entire file and then closes the stream', async () => {
     const readIterator = new FileChunkIterator(testData, {chunkSize: 10});
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result.length).toEqual(6);
     const totalBytes = result.map(x => x.length).reduce((a, b) => a + b);
     expect(totalBytes).toEqual(55);
@@ -38,7 +38,7 @@ describe('FileChunkIterator', () => {
 
   it('Reads chunks in order', async () => {
     const readIterator = new FileChunkIterator(testData, {chunkSize: 10});
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result[0][0]).toEqual(0);
     expect(result[1][0]).toEqual(10);
     expect(result[2][0]).toEqual(20);
@@ -49,7 +49,7 @@ describe('FileChunkIterator', () => {
 
   it('Reads chunks of expected sizes', async () => {
     const readIterator = new FileChunkIterator(testData, {chunkSize: 10});
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result[0].length).toEqual(10);
     expect(result[1].length).toEqual(10);
     expect(result[2].length).toEqual(10);

--- a/src/iterators/lazy_iterator.ts
+++ b/src/iterators/lazy_iterator.ts
@@ -161,28 +161,15 @@ export abstract class LazyIterator<T> {
    * Obviously this will succeed only for small streams that fit in memory.
    * Useful for testing.
    *
-   * @param maxItems the maximum number of items to return.  If the stream
-   *   terminates, fewer items will be returned.  (default 1000)
-   * @param prefetch the size of the prefetch buffer to use when collecting
-   *   items.  Some amount of prefetch is important to test parallel streams,
-   *   i.e. with multiple Promises outstanding.  Without prefetch, this method
-   *   makes purely serial next() calls.
-   *
    * @returns A Promise for an array of stream elements, which will resolve
    *   when the stream is exhausted.
    */
-  async collect(maxItems = 1000, prefetch = 100): Promise<T[]> {
-    const stream = prefetch > 0 ? this.prefetch(prefetch) : this;
+  async collect(): Promise<T[]> {
     const result: T[] = [];
-    let count = 0;
-    let x = await stream.next();
+    let x = await this.next();
     while (!x.done) {
       result.push(x.value);
-      count++;
-      if (count >= maxItems) {
-        return result;
-      }
-      x = await stream.next();
+      x = await this.next();
     }
     return result;
   }

--- a/src/iterators/lazy_iterator.ts
+++ b/src/iterators/lazy_iterator.ts
@@ -175,11 +175,12 @@ export abstract class LazyIterator<T> {
   }
 
   /**
-   * This is useful for testing, because the prefetch changes the order in which
-   * the Promises are resolved along the processing pipeline. This may help
-   * expose bugs where results are dependent on the order of Promise resolution
-   * rather than on the logical order of the stream (i.e., due to hidden mutable
-   * state).
+   * Collect all elements of this dataset into an array with prefetching 100
+   * elements. This is useful for testing, because the prefetch changes the
+   * order in which the Promises are resolved along the processing pipeline.
+   * This may help expose bugs where results are dependent on the order of
+   * Promise resolution rather than on the logical order of the stream (i.e.,
+   * due to hidden mutable state).
    *
    * @returns A Promise for an array of stream elements, which will resolve
    *   when the stream is exhausted.

--- a/src/iterators/lazy_iterator.ts
+++ b/src/iterators/lazy_iterator.ts
@@ -164,12 +164,31 @@ export abstract class LazyIterator<T> {
    * @returns A Promise for an array of stream elements, which will resolve
    *   when the stream is exhausted.
    */
-  async collect(): Promise<T[]> {
+  async toArray(): Promise<T[]> {
     const result: T[] = [];
     let x = await this.next();
     while (!x.done) {
       result.push(x.value);
       x = await this.next();
+    }
+    return result;
+  }
+
+  /**
+   * Collect all remaining elements of a bounded stream into an array with
+   * prefetching 100 elements. This is only used for testing with potential
+   * async scheduling.
+   *
+   * @returns A Promise for an array of stream elements, which will resolve
+   *   when the stream is exhausted.
+   */
+  async toArrayForTest(): Promise<T[]> {
+    const stream = this.prefetch(100);
+    const result: T[] = [];
+    let x = await stream.next();
+    while (!x.done) {
+      result.push(x.value);
+      x = await stream.next();
     }
     return result;
   }

--- a/src/iterators/lazy_iterator.ts
+++ b/src/iterators/lazy_iterator.ts
@@ -175,9 +175,11 @@ export abstract class LazyIterator<T> {
   }
 
   /**
-   * Collect all remaining elements of a bounded stream into an array with
-   * prefetching 100 elements. This is only used for testing with potential
-   * async scheduling.
+   * This is useful for testing, because the prefetch changes the order in which
+   * the Promises are resolved along the processing pipeline. This may help
+   * expose bugs where results are dependent on the order of Promise resolution
+   * rather than on the logical order of the stream (i.e., due to hidden mutable
+   * state).
    *
    * @returns A Promise for an array of stream elements, which will resolve
    *   when the stream is exhausted.

--- a/src/iterators/lazy_iterator_test.ts
+++ b/src/iterators/lazy_iterator_test.ts
@@ -52,13 +52,13 @@ export class TestIntegerIterator extends LazyIterator<number> {
 describe('LazyIterator', () => {
   it('collects all stream elements into an array', async () => {
     const readIterator = new TestIntegerIterator();
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result.length).toEqual(100);
   });
 
   it('reads chunks in order', async () => {
     const readIterator = new TestIntegerIterator();
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result.length).toEqual(100);
     for (let i = 0; i < 100; i++) {
       expect(result[i]).toEqual(i);
@@ -67,7 +67,7 @@ describe('LazyIterator', () => {
 
   it('filters elements', async () => {
     const readIterator = new TestIntegerIterator().filter(x => x % 2 === 0);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result.length).toEqual(50);
     for (let i = 0; i < 50; i++) {
       expect(result[i]).toEqual(2 * i);
@@ -76,7 +76,7 @@ describe('LazyIterator', () => {
 
   it('maps elements', async () => {
     const readIterator = new TestIntegerIterator().map(x => `item ${x}`);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result.length).toEqual(100);
     for (let i = 0; i < 100; i++) {
       expect(result[i]).toEqual(`item ${i}`);
@@ -107,7 +107,7 @@ describe('LazyIterator', () => {
   it('flatmaps simple elements', async () => {
     const readStream = new TestIntegerIterator().flatmap(
         x => [`item ${x} A`, `item ${x} B`, `item ${x} C`]);
-    const result = await readStream.collect();
+    const result = await readStream.prefetch(100).collect();
     expect(result.length).toEqual(300);
     for (let i = 0; i < 100; i++) {
       expect(result[3 * i + 0]).toEqual(`item ${i} A`);
@@ -123,7 +123,7 @@ describe('LazyIterator', () => {
              {foo: `foo ${x} B`, bar: `bar ${x} B`},
              {foo: `foo ${x} C`, bar: `bar ${x} C`},
     ]);
-    const result = await readStream.collect();
+    const result = await readStream.prefetch(100).collect();
     expect(result.length).toEqual(300);
     for (let i = 0; i < 100; i++) {
       expect(result[3 * i + 0]).toEqual({foo: `foo ${i} A`, bar: `bar ${i} A`});
@@ -139,7 +139,7 @@ describe('LazyIterator', () => {
             [`foo ${x} B`, `bar ${x} B`],
             [`foo ${x} C`, `bar ${x} C`],
     ]);
-    const result = await readStream.collect();
+    const result = await readStream.prefetch(100).collect();
     expect(result.length).toEqual(300);
     for (let i = 0; i < 100; i++) {
       expect(result[3 * i + 0]).toEqual([`foo ${i} A`, `bar ${i} A`]);
@@ -150,7 +150,7 @@ describe('LazyIterator', () => {
 
   it('batches elements to a row-major representation', async () => {
     const readIterator = new TestIntegerIterator().rowMajorBatch(8);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result.length).toEqual(13);
     for (let i = 0; i < 12; i++) {
       expect(result[i]).toEqual(Array.from({length: 8}, (v, k) => (i * 8) + k));
@@ -160,7 +160,7 @@ describe('LazyIterator', () => {
 
   it('batches elements to a column-major representation', async () => {
     const readIterator = new TestIntegerIterator().columnMajorBatch(8);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result.length).toEqual(13);
     for (let i = 0; i < 12; i++) {
       expect(result[i]).toEqual(Array.from({length: 8}, (v, k) => (i * 8) + k));
@@ -170,35 +170,35 @@ describe('LazyIterator', () => {
 
   it('can be limited to a certain number of elements', async () => {
     const readIterator = new TestIntegerIterator().take(8);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
   });
 
   it('is unaltered by a negative or undefined take() count.', async () => {
     const baseIterator = new TestIntegerIterator();
     const readIterator = baseIterator.take(-1);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result).toEqual(baseIterator.data);
     const baseIterator2 = new TestIntegerIterator();
     const readIterator2 = baseIterator2.take(undefined);
-    const result2 = await readIterator2.collect();
+    const result2 = await readIterator2.prefetch(100).collect();
     expect(result2).toEqual(baseIterator2.data);
   });
 
   it('can skip a certain number of elements', async () => {
     const readIterator = new TestIntegerIterator().skip(88).take(8);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result).toEqual([88, 89, 90, 91, 92, 93, 94, 95]);
   });
 
   it('is unaltered by a negative or undefined skip() count.', async () => {
     const baseIterator = new TestIntegerIterator();
     const readIterator = baseIterator.skip(-1);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result).toEqual(baseIterator.data);
     const baseIterator2 = new TestIntegerIterator();
     const readIterator2 = baseIterator2.skip(undefined);
-    const result2 = await readIterator2.collect();
+    const result2 = await readIterator2.prefetch(100).collect();
     expect(result2).toEqual(baseIterator2.data);
   });
 
@@ -211,7 +211,7 @@ describe('LazyIterator', () => {
     });
     // The 'true' response means the iterator should continue.
     const errorIgnoringIterator = readIterator.handleErrors((e) => true);
-    const result = await errorIgnoringIterator.collect();
+    const result = await errorIgnoringIterator.prefetch(100).collect();
     expect(result).toEqual([1, 3, 5, 7, 9]);
   });
 
@@ -226,7 +226,7 @@ describe('LazyIterator', () => {
     // But in the case of 10, return false, terminating the stream.
     const errorHandlingIterator = readIterator.handleErrors(
         (e) => e.message !== 'Oh no, an even number: 10');
-    const result = await errorHandlingIterator.collect();
+    const result = await errorHandlingIterator.prefetch(100).collect();
     expect(result).toEqual([1, 3, 5, 7, 9]);
   });
 
@@ -244,7 +244,7 @@ describe('LazyIterator', () => {
       return true;
     });
     try {
-      await errorHandlingIterator.collect(1000, 0);
+      await errorHandlingIterator.collect();
       done.fail();
     } catch (e) {
       expect(e.message).toEqual('Oh no, an even number: 2');
@@ -283,17 +283,17 @@ describe('LazyIterator', () => {
 
     // Without enforcing serial execution, order gets scrambled; consequently
     // the done signal arrives before any of the accepted elements!
-    const badResult = await newReadIterator().collect();
+    const badResult = await newReadIterator().prefetch(100).collect();
     expect(badResult).toEqual([0]);
 
     // But with serial execution, everything is fine.
-    const goodResult = await newReadIterator().serial().collect();
+    const goodResult = await newReadIterator().serial().prefetch(100).collect();
     expect(goodResult).toEqual([0, 2, 4, 6, 8]);
   });
 
   it('can be created from an array', async () => {
     const readIterator = iteratorFromItems([1, 2, 3, 4, 5, 6]);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
@@ -303,13 +303,13 @@ describe('LazyIterator', () => {
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
 
     const readIterator = iteratorFromFunction(func);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result).toEqual([0, 1, 2, 3, 4, 5, 6]);
   });
 
   it('can be created with incrementing integers', async () => {
     const readIterator = iteratorFromIncrementing(0).take(7);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result).toEqual([0, 1, 2, 3, 4, 5, 6]);
   });
 
@@ -317,7 +317,7 @@ describe('LazyIterator', () => {
     const a = iteratorFromItems([1, 2, 3]);
     const b = iteratorFromItems([4, 5, 6]);
     const readIterator = a.concatenate(b);
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
@@ -325,7 +325,7 @@ describe('LazyIterator', () => {
     const a = new TestIntegerIterator();
     const b = new TestIntegerIterator();
     const readIterator = iteratorFromConcatenated(iteratorFromItems([a, b]));
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result.length).toEqual(200);
   });
 
@@ -339,7 +339,7 @@ describe('LazyIterator', () => {
       }
     }
 
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result).toEqual(expectedResult);
   });
 
@@ -348,7 +348,7 @@ describe('LazyIterator', () => {
     const b = new TestIntegerIterator().map(x => x * 10);
     const c = new TestIntegerIterator().map(x => `string ${x}`);
     const readStream = iteratorFromZipped([a, b, c]);
-    const result = await readStream.collect();
+    const result = await readStream.prefetch(100).collect();
     expect(result.length).toEqual(100);
 
     // each result has the form [x, x * 10, 'string ' + x]
@@ -365,7 +365,7 @@ describe('LazyIterator', () => {
     const b = new TestIntegerIterator().map(x => x * 10);
     const c = new TestIntegerIterator().map(x => `string ${x}`);
     const readStream = iteratorFromZipped({a, b, c});
-    const result = await readStream.collect();
+    const result = await readStream.prefetch(100).collect();
     expect(result.length).toEqual(100);
 
     // each result has the form {a: x, b: x * 10, c: 'string ' + x}
@@ -383,7 +383,7 @@ describe('LazyIterator', () => {
         x => ({'b': x * 10, 'array': [x * 100, x * 200]}));
     const c = new TestIntegerIterator().map(x => ({'c': `string ${x}`}));
     const readStream = iteratorFromZipped([a, b, c]);
-    const result = await readStream.collect();
+    const result = await readStream.prefetch(100).collect();
     expect(result.length).toEqual(100);
 
     // each result has the form
@@ -413,7 +413,7 @@ describe('LazyIterator', () => {
       const b = new TestIntegerIterator(3);
       const c = new TestIntegerIterator(2);
       const readStream = iteratorFromZipped([a, b, c]);
-      await readStream.collect(1000, 0);
+      await readStream.collect();
       done.fail();
     } catch (error) {
       expect(error.message)
@@ -431,7 +431,7 @@ describe('LazyIterator', () => {
        const c = new TestIntegerIterator(2);
        const readStream =
            iteratorFromZipped([a, b, c], ZipMismatchMode.SHORTEST);
-       const result = await readStream.collect();
+       const result = await readStream.prefetch(100).collect();
        expect(result.length).toEqual(2);
      });
 
@@ -442,7 +442,7 @@ describe('LazyIterator', () => {
        const c = new TestIntegerIterator(2);
        const readStream =
            iteratorFromZipped([a, b, c], ZipMismatchMode.LONGEST);
-       const result = await readStream.collect();
+       const result = await readStream.prefetch(100).collect();
        expect(result.length).toEqual(10);
        expect(result[9]).toEqual([9, null, null]);
      });
@@ -472,7 +472,7 @@ describe('LazyIterator', () => {
     const readStream = zippedStream.map(e => naiveMerge(e as DataElementArray));
     // Now each result has the form {a: x, b: x * 10, c: 'string ' + x}
 
-    const result = await readStream.collect();
+    const result = await readStream.prefetch(100).collect();
     expect(result.length).toEqual(100);
 
     for (const e of result) {

--- a/src/iterators/lazy_iterator_test.ts
+++ b/src/iterators/lazy_iterator_test.ts
@@ -244,6 +244,10 @@ describe('LazyIterator', () => {
       return true;
     });
     try {
+      // Using toArray() rather than toArrayForTest().  The prefetch in
+      // the latter, in combination with expecting an exception, causes
+      // unrelated tests to fail (See
+      // https://github.com/tensorflow/tfjs/issues/1330.
       await errorHandlingIterator.toArray();
       done.fail();
     } catch (e) {
@@ -413,6 +417,10 @@ describe('LazyIterator', () => {
       const b = new TestIntegerIterator(3);
       const c = new TestIntegerIterator(2);
       const readStream = iteratorFromZipped([a, b, c]);
+      // Using toArray() rather than toArrayForTest().  The prefetch in
+      // the latter, in combination with expecting an exception, causes
+      // unrelated tests to fail (See
+      // https://github.com/tensorflow/tfjs/issues/1330.
       await readStream.toArray();
       done.fail();
     } catch (error) {

--- a/src/iterators/lazy_iterator_test.ts
+++ b/src/iterators/lazy_iterator_test.ts
@@ -52,13 +52,13 @@ export class TestIntegerIterator extends LazyIterator<number> {
 describe('LazyIterator', () => {
   it('collects all stream elements into an array', async () => {
     const readIterator = new TestIntegerIterator();
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result.length).toEqual(100);
   });
 
   it('reads chunks in order', async () => {
     const readIterator = new TestIntegerIterator();
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result.length).toEqual(100);
     for (let i = 0; i < 100; i++) {
       expect(result[i]).toEqual(i);
@@ -67,7 +67,7 @@ describe('LazyIterator', () => {
 
   it('filters elements', async () => {
     const readIterator = new TestIntegerIterator().filter(x => x % 2 === 0);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result.length).toEqual(50);
     for (let i = 0; i < 50; i++) {
       expect(result[i]).toEqual(2 * i);
@@ -76,7 +76,7 @@ describe('LazyIterator', () => {
 
   it('maps elements', async () => {
     const readIterator = new TestIntegerIterator().map(x => `item ${x}`);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result.length).toEqual(100);
     for (let i = 0; i < 100; i++) {
       expect(result[i]).toEqual(`item ${i}`);
@@ -97,7 +97,7 @@ describe('LazyIterator', () => {
     // It's important to prefetch in order to test the promise randomization
     // above.  Note collect() already prefetches by default, but here we do it
     // explicitly anyway just to be extra clear.
-    const result = await readIterator.prefetch(200).collect();
+    const result = await readIterator.prefetch(200).toArray();
     expect(result.length).toEqual(100);
     for (let i = 0; i < 100; i++) {
       expect(result[i]).toEqual(`item ${i}`);
@@ -107,7 +107,7 @@ describe('LazyIterator', () => {
   it('flatmaps simple elements', async () => {
     const readStream = new TestIntegerIterator().flatmap(
         x => [`item ${x} A`, `item ${x} B`, `item ${x} C`]);
-    const result = await readStream.prefetch(100).collect();
+    const result = await readStream.toArrayForTest();
     expect(result.length).toEqual(300);
     for (let i = 0; i < 100; i++) {
       expect(result[3 * i + 0]).toEqual(`item ${i} A`);
@@ -123,7 +123,7 @@ describe('LazyIterator', () => {
              {foo: `foo ${x} B`, bar: `bar ${x} B`},
              {foo: `foo ${x} C`, bar: `bar ${x} C`},
     ]);
-    const result = await readStream.prefetch(100).collect();
+    const result = await readStream.toArrayForTest();
     expect(result.length).toEqual(300);
     for (let i = 0; i < 100; i++) {
       expect(result[3 * i + 0]).toEqual({foo: `foo ${i} A`, bar: `bar ${i} A`});
@@ -139,7 +139,7 @@ describe('LazyIterator', () => {
             [`foo ${x} B`, `bar ${x} B`],
             [`foo ${x} C`, `bar ${x} C`],
     ]);
-    const result = await readStream.prefetch(100).collect();
+    const result = await readStream.toArrayForTest();
     expect(result.length).toEqual(300);
     for (let i = 0; i < 100; i++) {
       expect(result[3 * i + 0]).toEqual([`foo ${i} A`, `bar ${i} A`]);
@@ -150,7 +150,7 @@ describe('LazyIterator', () => {
 
   it('batches elements to a row-major representation', async () => {
     const readIterator = new TestIntegerIterator().rowMajorBatch(8);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result.length).toEqual(13);
     for (let i = 0; i < 12; i++) {
       expect(result[i]).toEqual(Array.from({length: 8}, (v, k) => (i * 8) + k));
@@ -160,7 +160,7 @@ describe('LazyIterator', () => {
 
   it('batches elements to a column-major representation', async () => {
     const readIterator = new TestIntegerIterator().columnMajorBatch(8);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result.length).toEqual(13);
     for (let i = 0; i < 12; i++) {
       expect(result[i]).toEqual(Array.from({length: 8}, (v, k) => (i * 8) + k));
@@ -170,35 +170,35 @@ describe('LazyIterator', () => {
 
   it('can be limited to a certain number of elements', async () => {
     const readIterator = new TestIntegerIterator().take(8);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
   });
 
   it('is unaltered by a negative or undefined take() count.', async () => {
     const baseIterator = new TestIntegerIterator();
     const readIterator = baseIterator.take(-1);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result).toEqual(baseIterator.data);
     const baseIterator2 = new TestIntegerIterator();
     const readIterator2 = baseIterator2.take(undefined);
-    const result2 = await readIterator2.prefetch(100).collect();
+    const result2 = await readIterator2.toArrayForTest();
     expect(result2).toEqual(baseIterator2.data);
   });
 
   it('can skip a certain number of elements', async () => {
     const readIterator = new TestIntegerIterator().skip(88).take(8);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result).toEqual([88, 89, 90, 91, 92, 93, 94, 95]);
   });
 
   it('is unaltered by a negative or undefined skip() count.', async () => {
     const baseIterator = new TestIntegerIterator();
     const readIterator = baseIterator.skip(-1);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result).toEqual(baseIterator.data);
     const baseIterator2 = new TestIntegerIterator();
     const readIterator2 = baseIterator2.skip(undefined);
-    const result2 = await readIterator2.prefetch(100).collect();
+    const result2 = await readIterator2.toArrayForTest();
     expect(result2).toEqual(baseIterator2.data);
   });
 
@@ -211,7 +211,7 @@ describe('LazyIterator', () => {
     });
     // The 'true' response means the iterator should continue.
     const errorIgnoringIterator = readIterator.handleErrors((e) => true);
-    const result = await errorIgnoringIterator.prefetch(100).collect();
+    const result = await errorIgnoringIterator.toArrayForTest();
     expect(result).toEqual([1, 3, 5, 7, 9]);
   });
 
@@ -226,7 +226,7 @@ describe('LazyIterator', () => {
     // But in the case of 10, return false, terminating the stream.
     const errorHandlingIterator = readIterator.handleErrors(
         (e) => e.message !== 'Oh no, an even number: 10');
-    const result = await errorHandlingIterator.prefetch(100).collect();
+    const result = await errorHandlingIterator.toArrayForTest();
     expect(result).toEqual([1, 3, 5, 7, 9]);
   });
 
@@ -244,7 +244,7 @@ describe('LazyIterator', () => {
       return true;
     });
     try {
-      await errorHandlingIterator.collect();
+      await errorHandlingIterator.toArray();
       done.fail();
     } catch (e) {
       expect(e.message).toEqual('Oh no, an even number: 2');
@@ -283,17 +283,17 @@ describe('LazyIterator', () => {
 
     // Without enforcing serial execution, order gets scrambled; consequently
     // the done signal arrives before any of the accepted elements!
-    const badResult = await newReadIterator().prefetch(100).collect();
+    const badResult = await newReadIterator().toArrayForTest();
     expect(badResult).toEqual([0]);
 
     // But with serial execution, everything is fine.
-    const goodResult = await newReadIterator().serial().prefetch(100).collect();
+    const goodResult = await newReadIterator().serial().toArrayForTest();
     expect(goodResult).toEqual([0, 2, 4, 6, 8]);
   });
 
   it('can be created from an array', async () => {
     const readIterator = iteratorFromItems([1, 2, 3, 4, 5, 6]);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
@@ -303,13 +303,13 @@ describe('LazyIterator', () => {
         ++i < 7 ? {value: i, done: false} : {value: null, done: true};
 
     const readIterator = iteratorFromFunction(func);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result).toEqual([0, 1, 2, 3, 4, 5, 6]);
   });
 
   it('can be created with incrementing integers', async () => {
     const readIterator = iteratorFromIncrementing(0).take(7);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result).toEqual([0, 1, 2, 3, 4, 5, 6]);
   });
 
@@ -317,7 +317,7 @@ describe('LazyIterator', () => {
     const a = iteratorFromItems([1, 2, 3]);
     const b = iteratorFromItems([4, 5, 6]);
     const readIterator = a.concatenate(b);
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
@@ -325,7 +325,7 @@ describe('LazyIterator', () => {
     const a = new TestIntegerIterator();
     const b = new TestIntegerIterator();
     const readIterator = iteratorFromConcatenated(iteratorFromItems([a, b]));
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result.length).toEqual(200);
   });
 
@@ -339,7 +339,7 @@ describe('LazyIterator', () => {
       }
     }
 
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result).toEqual(expectedResult);
   });
 
@@ -348,7 +348,7 @@ describe('LazyIterator', () => {
     const b = new TestIntegerIterator().map(x => x * 10);
     const c = new TestIntegerIterator().map(x => `string ${x}`);
     const readStream = iteratorFromZipped([a, b, c]);
-    const result = await readStream.prefetch(100).collect();
+    const result = await readStream.toArrayForTest();
     expect(result.length).toEqual(100);
 
     // each result has the form [x, x * 10, 'string ' + x]
@@ -365,7 +365,7 @@ describe('LazyIterator', () => {
     const b = new TestIntegerIterator().map(x => x * 10);
     const c = new TestIntegerIterator().map(x => `string ${x}`);
     const readStream = iteratorFromZipped({a, b, c});
-    const result = await readStream.prefetch(100).collect();
+    const result = await readStream.toArrayForTest();
     expect(result.length).toEqual(100);
 
     // each result has the form {a: x, b: x * 10, c: 'string ' + x}
@@ -383,7 +383,7 @@ describe('LazyIterator', () => {
         x => ({'b': x * 10, 'array': [x * 100, x * 200]}));
     const c = new TestIntegerIterator().map(x => ({'c': `string ${x}`}));
     const readStream = iteratorFromZipped([a, b, c]);
-    const result = await readStream.prefetch(100).collect();
+    const result = await readStream.toArrayForTest();
     expect(result.length).toEqual(100);
 
     // each result has the form
@@ -413,7 +413,7 @@ describe('LazyIterator', () => {
       const b = new TestIntegerIterator(3);
       const c = new TestIntegerIterator(2);
       const readStream = iteratorFromZipped([a, b, c]);
-      await readStream.collect();
+      await readStream.toArray();
       done.fail();
     } catch (error) {
       expect(error.message)
@@ -431,7 +431,7 @@ describe('LazyIterator', () => {
        const c = new TestIntegerIterator(2);
        const readStream =
            iteratorFromZipped([a, b, c], ZipMismatchMode.SHORTEST);
-       const result = await readStream.prefetch(100).collect();
+       const result = await readStream.toArrayForTest();
        expect(result.length).toEqual(2);
      });
 
@@ -442,7 +442,7 @@ describe('LazyIterator', () => {
        const c = new TestIntegerIterator(2);
        const readStream =
            iteratorFromZipped([a, b, c], ZipMismatchMode.LONGEST);
-       const result = await readStream.prefetch(100).collect();
+       const result = await readStream.toArrayForTest();
        expect(result.length).toEqual(10);
        expect(result[9]).toEqual([9, null, null]);
      });
@@ -472,7 +472,7 @@ describe('LazyIterator', () => {
     const readStream = zippedStream.map(e => naiveMerge(e as DataElementArray));
     // Now each result has the form {a: x, b: x * 10, c: 'string ' + x}
 
-    const result = await readStream.prefetch(100).collect();
+    const result = await readStream.toArrayForTest();
     expect(result.length).toEqual(100);
 
     for (const e of result) {

--- a/src/iterators/prefetch_iterator_test.ts
+++ b/src/iterators/prefetch_iterator_test.ts
@@ -29,7 +29,7 @@ describe('PrefetchIterator', () => {
       expectedResult[j] = j;
     }
 
-    const result = await prefetchIterator.collect();
+    const result = await prefetchIterator.toArray();
     expect(result).toEqual(expectedResult);
   });
 
@@ -47,7 +47,7 @@ describe('PrefetchIterator', () => {
          }
        }
 
-       const result = await prefetchIterator.collect();
+       const result = await prefetchIterator.toArray();
        expect(result).toEqual(expectedResult);
      });
 
@@ -64,7 +64,7 @@ describe('PrefetchIterator', () => {
          }
        }
 
-       const result = await prefetchIterator.collect();
+       const result = await prefetchIterator.toArray();
        expect(result).toEqual(expectedResult);
      });
 });

--- a/src/iterators/shuffle_iterator_test.ts
+++ b/src/iterators/shuffle_iterator_test.ts
@@ -34,7 +34,7 @@ describe('ShuffleIterator', () => {
         notExpectedResult[i * LONG_STREAM_LENGTH + j] = j;
       }
     }
-    const result = await shuffleIterator.collect();
+    const result = await shuffleIterator.prefetch(100).collect();
     expect(result).not.toEqual(notExpectedResult);
     expect(result.length).toEqual(LONG_STREAM_LENGTH);
     const counts = new Array<number>(LONG_STREAM_LENGTH);
@@ -56,7 +56,7 @@ describe('ShuffleIterator', () => {
         notExpectedResult[i * SHORT_STREAM_LENGTH + j] = j;
       }
     }
-    const result = await shuffleIterator.collect();
+    const result = await shuffleIterator.prefetch(100).collect();
     expect(result).not.toEqual(notExpectedResult);
     expect(result.length).toEqual(SHORT_STREAM_LENGTH);
     const counts = new Array<number>(SHORT_STREAM_LENGTH);
@@ -80,7 +80,7 @@ describe('ShuffleIterator', () => {
         notExpectedResult[i * SHORT_STREAM_LENGTH + j] = j;
       }
     }
-    const result = await shuffleIterator.collect();
+    const result = await shuffleIterator.prefetch(100).collect();
     expect(result).not.toEqual(notExpectedResult);
     expect(result.length).toEqual(3 * SHORT_STREAM_LENGTH);
     const counts = new Array<number>(SHORT_STREAM_LENGTH);

--- a/src/iterators/shuffle_iterator_test.ts
+++ b/src/iterators/shuffle_iterator_test.ts
@@ -34,7 +34,7 @@ describe('ShuffleIterator', () => {
         notExpectedResult[i * LONG_STREAM_LENGTH + j] = j;
       }
     }
-    const result = await shuffleIterator.prefetch(100).collect();
+    const result = await shuffleIterator.toArrayForTest();
     expect(result).not.toEqual(notExpectedResult);
     expect(result.length).toEqual(LONG_STREAM_LENGTH);
     const counts = new Array<number>(LONG_STREAM_LENGTH);
@@ -56,7 +56,7 @@ describe('ShuffleIterator', () => {
         notExpectedResult[i * SHORT_STREAM_LENGTH + j] = j;
       }
     }
-    const result = await shuffleIterator.prefetch(100).collect();
+    const result = await shuffleIterator.toArrayForTest();
     expect(result).not.toEqual(notExpectedResult);
     expect(result.length).toEqual(SHORT_STREAM_LENGTH);
     const counts = new Array<number>(SHORT_STREAM_LENGTH);
@@ -80,7 +80,7 @@ describe('ShuffleIterator', () => {
         notExpectedResult[i * SHORT_STREAM_LENGTH + j] = j;
       }
     }
-    const result = await shuffleIterator.prefetch(100).collect();
+    const result = await shuffleIterator.toArrayForTest();
     expect(result).not.toEqual(notExpectedResult);
     expect(result.length).toEqual(3 * SHORT_STREAM_LENGTH);
     const counts = new Array<number>(SHORT_STREAM_LENGTH);

--- a/src/iterators/string_iterator_test.ts
+++ b/src/iterators/string_iterator_test.ts
@@ -35,7 +35,7 @@ describe('StringIterator.split()', () => {
     const lineIterator = utf8Iterator.split('\n');
     const expected = lorem.split('\n');
 
-    const result = await lineIterator.prefetch(100).collect();
+    const result = await lineIterator.toArrayForTest();
     expect(result.length).toEqual(6);
     const totalCharacters = result.map(x => x.length).reduce((a, b) => a + b);
     expect(totalCharacters).toEqual(440);
@@ -59,7 +59,7 @@ describe('StringIterator.split()', () => {
        const lineIterator = utf8Iterator.split(' ');
        const expected = ['ab', 'def', 'hi', '', '', '', '', '', 'pq'];
 
-       const result = await lineIterator.prefetch(100).collect();
+       const result = await lineIterator.toArrayForTest();
        expect(result.length).toEqual(9);
        const totalCharacters =
            result.map(x => x.length).reduce((a, b) => a + b);

--- a/src/iterators/string_iterator_test.ts
+++ b/src/iterators/string_iterator_test.ts
@@ -35,7 +35,7 @@ describe('StringIterator.split()', () => {
     const lineIterator = utf8Iterator.split('\n');
     const expected = lorem.split('\n');
 
-    const result = await lineIterator.collect();
+    const result = await lineIterator.prefetch(100).collect();
     expect(result.length).toEqual(6);
     const totalCharacters = result.map(x => x.length).reduce((a, b) => a + b);
     expect(totalCharacters).toEqual(440);
@@ -59,7 +59,7 @@ describe('StringIterator.split()', () => {
        const lineIterator = utf8Iterator.split(' ');
        const expected = ['ab', 'def', 'hi', '', '', '', '', '', 'pq'];
 
-       const result = await lineIterator.collect();
+       const result = await lineIterator.prefetch(100).collect();
        expect(result.length).toEqual(9);
        const totalCharacters =
            result.map(x => x.length).reduce((a, b) => a + b);

--- a/src/iterators/url_chunk_iterator_test.ts
+++ b/src/iterators/url_chunk_iterator_test.ts
@@ -35,7 +35,7 @@ nock(url).get('/').times(3).reply(200, testString);
 describe('URLChunkIterator', () => {
   it('Reads the entire file and then closes the stream', async () => {
     const readIterator = await urlChunkIterator(url, {chunkSize: 10});
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result.length).toEqual(3);
     const totalBytes = result.map(x => x.length).reduce((a, b) => a + b);
     expect(totalBytes).toEqual(26);
@@ -44,7 +44,7 @@ describe('URLChunkIterator', () => {
   it('Reads chunks in order', async () => {
     const readIterator = await urlChunkIterator(url, {chunkSize: 10});
 
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result[0][0]).toEqual('a'.charCodeAt(0));
     expect(result[1][0]).toEqual('k'.charCodeAt(0));
     expect(result[2][0]).toEqual('u'.charCodeAt(0));
@@ -53,7 +53,7 @@ describe('URLChunkIterator', () => {
   it('Reads chunks of expected sizes', async () => {
     const readIterator = await urlChunkIterator(url, {chunkSize: 10});
 
-    const result = await readIterator.collect();
+    const result = await readIterator.prefetch(100).collect();
     expect(result[0].length).toEqual(10);
     expect(result[1].length).toEqual(10);
     expect(result[2].length).toEqual(6);

--- a/src/iterators/url_chunk_iterator_test.ts
+++ b/src/iterators/url_chunk_iterator_test.ts
@@ -35,7 +35,7 @@ nock(url).get('/').times(3).reply(200, testString);
 describe('URLChunkIterator', () => {
   it('Reads the entire file and then closes the stream', async () => {
     const readIterator = await urlChunkIterator(url, {chunkSize: 10});
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result.length).toEqual(3);
     const totalBytes = result.map(x => x.length).reduce((a, b) => a + b);
     expect(totalBytes).toEqual(26);
@@ -44,7 +44,7 @@ describe('URLChunkIterator', () => {
   it('Reads chunks in order', async () => {
     const readIterator = await urlChunkIterator(url, {chunkSize: 10});
 
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result[0][0]).toEqual('a'.charCodeAt(0));
     expect(result[1][0]).toEqual('k'.charCodeAt(0));
     expect(result[2][0]).toEqual('u'.charCodeAt(0));
@@ -53,7 +53,7 @@ describe('URLChunkIterator', () => {
   it('Reads chunks of expected sizes', async () => {
     const readIterator = await urlChunkIterator(url, {chunkSize: 10});
 
-    const result = await readIterator.prefetch(100).collect();
+    const result = await readIterator.toArrayForTest();
     expect(result[0].length).toEqual(10);
     expect(result[1].length).toEqual(10);
     expect(result[2].length).toEqual(6);

--- a/src/readers_test.ts
+++ b/src/readers_test.ts
@@ -25,7 +25,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
     const f = () =>
         ++i < 5 ? {value: i, done: false} : {value: null, done: true};
     const ds = tfd.func(f);
-    const result = await ds.prefetch(100).toArray();
+    const result = await ds.toArrayForTest();
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
 
@@ -40,7 +40,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       }
     }
     const ds = tfd.generator(dataGenerator);
-    const result = await ds.prefetch(100).toArray();
+    const result = await ds.toArrayForTest();
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
 
@@ -55,9 +55,9 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       }
     }
     const ds = tfd.generator(dataGenerator);
-    const result1 = await ds.prefetch(100).toArray();
+    const result1 = await ds.toArrayForTest();
     expect(result1).toEqual([0, 1, 2, 3, 4]);
-    const result2 = await ds.prefetch(100).toArray();
+    const result2 = await ds.toArrayForTest();
     expect(result2).toEqual([0, 1, 2, 3, 4]);
   });
 
@@ -78,7 +78,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       return iterator;
     }
     const ds = tfd.generator(makeIterator);
-    const result = await ds.prefetch(100).toArray();
+    const result = await ds.toArrayForTest();
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
 
@@ -100,9 +100,9 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
          return iterator;
        }
        const ds = tfd.generator(makeIterator);
-       const result1 = await ds.prefetch(100).toArray();
+       const result1 = await ds.toArrayForTest();
        expect(result1).toEqual([0, 1, 2, 3, 4]);
-       const result2 = await ds.prefetch(100).toArray();
+       const result2 = await ds.toArrayForTest();
        expect(result2).toEqual([0, 1, 2, 3, 4]);
      });
 
@@ -130,7 +130,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       return iterator;
     }
     const ds = tfd.generator(makeIterator);
-    const result = await ds.prefetch(100).toArray();
+    const result = await ds.toArrayForTest();
     expect(result).toEqual([3, 4, 5]);
   });
 });

--- a/src/readers_test.ts
+++ b/src/readers_test.ts
@@ -25,7 +25,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
     const f = () =>
         ++i < 5 ? {value: i, done: false} : {value: null, done: true};
     const ds = tfd.func(f);
-    const result = await ds.toArray();
+    const result = await ds.prefetch(100).toArray();
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
 
@@ -40,7 +40,7 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       }
     }
     const ds = tfd.generator(dataGenerator);
-    const result = await ds.toArray();
+    const result = await ds.prefetch(100).toArray();
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
 
@@ -55,9 +55,9 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       }
     }
     const ds = tfd.generator(dataGenerator);
-    const result1 = await ds.toArray();
+    const result1 = await ds.prefetch(100).toArray();
     expect(result1).toEqual([0, 1, 2, 3, 4]);
-    const result2 = await ds.toArray();
+    const result2 = await ds.prefetch(100).toArray();
     expect(result2).toEqual([0, 1, 2, 3, 4]);
   });
 
@@ -78,33 +78,33 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       return iterator;
     }
     const ds = tfd.generator(makeIterator);
-    const result = await ds.toArray();
+    const result = await ds.prefetch(100).toArray();
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
 
   it('generate multiple datasets from JavaScript iterator factory',
-  async () => {
-    function makeIterator() {
-      let iterationCount = 0;
-      const iterator = {
-        next: () => {
-          let result;
-          if (iterationCount < 5) {
-            result = {value: iterationCount, done: false};
-            iterationCount++;
-            return result;
-          }
-          return {value: iterationCount, done: true};
-        }
-      };
-      return iterator;
-    }
-    const ds = tfd.generator(makeIterator);
-    const result1 = await ds.toArray();
-    expect(result1).toEqual([0, 1, 2, 3, 4]);
-    const result2 = await ds.toArray();
-    expect(result2).toEqual([0, 1, 2, 3, 4]);
-  });
+     async () => {
+       function makeIterator() {
+         let iterationCount = 0;
+         const iterator = {
+           next: () => {
+             let result;
+             if (iterationCount < 5) {
+               result = {value: iterationCount, done: false};
+               iterationCount++;
+               return result;
+             }
+             return {value: iterationCount, done: true};
+           }
+         };
+         return iterator;
+       }
+       const ds = tfd.generator(makeIterator);
+       const result1 = await ds.prefetch(100).toArray();
+       expect(result1).toEqual([0, 1, 2, 3, 4]);
+       const result2 = await ds.prefetch(100).toArray();
+       expect(result2).toEqual([0, 1, 2, 3, 4]);
+     });
 
   it('generate dataset from async iterator factory', async () => {
     async function waitAndCreateCount() {
@@ -115,22 +115,22 @@ describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
       });
     }
     async function makeIterator() {
-        let iterationCount = (await waitAndCreateCount()) as number;
-        const iterator = {
-          next: () => {
-            let result;
-            if (iterationCount < 6) {
-              result = {value: iterationCount, done: false};
-              iterationCount++;
-              return result;
-            }
-            return {value: iterationCount, done: true};
+      let iterationCount = (await waitAndCreateCount()) as number;
+      const iterator = {
+        next: () => {
+          let result;
+          if (iterationCount < 6) {
+            result = {value: iterationCount, done: false};
+            iterationCount++;
+            return result;
           }
-        };
-        return iterator;
+          return {value: iterationCount, done: true};
+        }
+      };
+      return iterator;
     }
     const ds = tfd.generator(makeIterator);
-    const result = await ds.toArray();
+    const result = await ds.prefetch(100).toArray();
     expect(result).toEqual([3, 4, 5]);
   });
 });


### PR DESCRIPTION
rename `iterator.collect()` to `iterator.toArray()`
remove `maxItems` and `prefetch` from `iterator.toArray()`
add `iterator.toArrayForTest()` which implement `.prefetch(100)` inside
throw an exception when calling `.toArray()` from dataset whose size is infinity

resolves https://github.com/tensorflow/tfjs/issues/1318
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/155)
<!-- Reviewable:end -->
