### PR TITLE
Remove tf.data.func()

### DIFF
--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -248,9 +248,7 @@ describeWithFlags(
              await (await tfd.zip([a, b]).iterator()).toArray();
              done.fail();
            } catch (e) {
-             expect(e.message).toEqual(
-                 'Error thrown while iterating through ' +
-                 'a dataset: propagate me!');
+             expect(e.message).toMatch(/propagate me!/);
              done();
            }
          });
@@ -737,7 +735,7 @@ describeWithFlags(
         expect(ds.size).toEqual(0);
       });
 
-      it('size is undefined if dataset may exhausted randomly', async () => {
+      it('size is null if dataset may exhausted randomly', async () => {
         const makeIterator = () => {
           let i = -1;
           const iterator = {
@@ -760,7 +758,7 @@ describeWithFlags(
         expect(ds.size).toEqual(Infinity);
       });
 
-      it('repeat undefined size dataset has undefined size', async () => {
+      it('repeat unknown size dataset has null size', async () => {
         const makeIterator = () => {
           let i = -1;
           const iterator = {
@@ -783,7 +781,7 @@ describeWithFlags(
         expect(ds.size).toEqual(5);
       });
 
-      it('take dataset with undefined size has undefined size', async () => {
+      it('take dataset with unknown size has null size', async () => {
         const makeIterator = () => {
           let i = -1;
           const iterator = {
@@ -811,7 +809,7 @@ describeWithFlags(
         expect(ds.size).toEqual(0);
       });
 
-      it('skip dataset with undefined size has undefined size', async () => {
+      it('skip dataset with unknown size has null size', async () => {
         const makeIterator = () => {
           let i = -1;
           const iterator = {
@@ -840,7 +838,7 @@ describeWithFlags(
            expect(ds.size).toEqual(3);
          });
 
-      it('batch dataset with undefined size has undefined size', async () => {
+      it('batch dataset with unknown size has null size', async () => {
         const makeIterator = () => {
           let i = -1;
           const iterator = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@
 export {array, Dataset, zip} from './dataset';
 export {CSVDataset} from './datasets/csv_dataset';
 export {TextLineDataset} from './datasets/text_line_dataset';
-export {csv, func, generator} from './readers';
+export {csv, generator} from './readers';
 export {FileDataSource} from './sources/file_data_source';
 export {URLDataSource} from './sources/url_data_source';
 export {ColumnConfig, DataElement} from './types';

--- a/src/readers.ts
+++ b/src/readers.ts
@@ -107,36 +107,6 @@ export function csv(
 }
 
 /**
- * Create a `Dataset` that produces each element by calling a provided function.
- *
- * Note that repeated iterations over this `Dataset` may produce different
- * results, because the function will be called anew for each element of each
- * iteration.
- *
- * Also, beware that the sequence of calls to this function may be out of order
- * in time with respect to the logical order of the Dataset. This is due to the
- * asynchronous lazy nature of stream processing, and depends on downstream
- * transformations (e.g. .shuffle()). If the provided function is pure, this is
- * no problem, but if it is a closure over a mutable state (e.g., a traversal
- * pointer), then the order of the produced elements may be scrambled.
- *
- * ```js
- * let i = -1;
- * const func = () =>
- *    ++i < 5 ? {value: i, done: false} : {value: null, done: true};
- * const ds = tf.data.func(func);
- * await ds.forEachAsync(e => console.log(e));
- * ```
- *
- * @param f A function that produces one data element on each call.
- */
-export function func<T extends DataElement>(
-    f: () => IteratorResult<T>| Promise<IteratorResult<T>>): Dataset<T> {
-  const iter = iteratorFromFunction(f);
-  return datasetFromIteratorFn(async () => iter);
-}
-
-/**
  * Create a `Dataset` that produces each element from provided JavaScript
  * generator, which is a function*
  * (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_functions),

--- a/src/readers_test.ts
+++ b/src/readers_test.ts
@@ -20,15 +20,6 @@ import {describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 import * as tfd from './readers';
 
 describeWithFlags('readers', tf.test_util.ALL_ENVS, () => {
-  it('generate dataset from function', async () => {
-    let i = -1;
-    const f = () =>
-        ++i < 5 ? {value: i, done: false} : {value: null, done: true};
-    const ds = tfd.func(f);
-    const result = await ds.toArrayForTest();
-    expect(result).toEqual([0, 1, 2, 3, 4]);
-  });
-
   it('generate dataset from JavaScript generator', async () => {
     function* dataGenerator() {
       const numElements = 5;


### PR DESCRIPTION
`tf.data.func()` has the same functionality as `tf.data.generator()` and user should use `tf.data.generator()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/166)
<!-- Reviewable:end -->
