### PR TITLE
Remove type `DataElement` and use type `TensorContainer` from tfjs-core

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -20,7 +20,7 @@ import * as tf from '@tensorflow/tfjs-core';
 import {TensorLike} from '@tensorflow/tfjs-core';
 import * as seedrandom from 'seedrandom';
 import {iteratorFromConcatenated, iteratorFromFunction, iteratorFromItems, iteratorFromZipped, LazyIterator, ZipMismatchMode} from './iterators/lazy_iterator';
-import {DataElement, DatasetContainer} from './types';
+import {DatasetContainer} from './types';
 import {canTensorify, deepMapAndAwaitAll, DeepMapResult, isIterable} from './util/deep_map';
 
 // TODO(soergel): consider vectorized operations within the pipeline.
@@ -52,7 +52,7 @@ import {canTensorify, deepMapAndAwaitAll, DeepMapResult, isIterable} from './uti
  * iterate once over the entire dataset in order to print out the data.
  */
 /** @doc {heading: 'Data', subheading: 'Classes', namespace: 'data'} */
-export abstract class Dataset<T extends DataElement> {
+export abstract class Dataset<T extends tf.TensorContainer> {
   /*
    * Provide a new stream of elements.  Note this will also start new streams
    * from any underlying `Dataset`s.
@@ -125,7 +125,7 @@ export abstract class Dataset<T extends DataElement> {
    * @returns A `Dataset`, from which a stream of batches can be obtained.
    */
   /** @doc {heading: 'Data', subheading: 'Classes'} */
-  batch(batchSize: number, smallLastBatch = true): Dataset<DataElement> {
+  batch(batchSize: number, smallLastBatch = true): Dataset<tf.TensorContainer> {
     const base = this;
     tf.util.assert(
         batchSize > 0, () => `batchSize needs to be positive, but it is
@@ -258,7 +258,7 @@ export abstract class Dataset<T extends DataElement> {
    * @returns A `Dataset` of transformed elements.
    */
   /** @doc {heading: 'Data', subheading: 'Classes'} */
-  map<O extends DataElement>(transform: (value: T) => O): Dataset<O> {
+  map<O extends tf.TensorContainer>(transform: (value: T) => O): Dataset<O> {
     const base = this;
     return datasetFromIteratorFn(async () => {
       return (await base.iterator()).map(x => tf.tidy(() => transform(x)));
@@ -286,7 +286,7 @@ export abstract class Dataset<T extends DataElement> {
    * @returns A `Dataset` of transformed elements.
    */
   /** @doc {heading: 'Data', subheading: 'Classes'} */
-  mapAsync<O extends DataElement>(transform: (value: T) => Promise<O>):
+  mapAsync<O extends tf.TensorContainer>(transform: (value: T) => Promise<O>):
       Dataset<O> {
     const base = this;
     return datasetFromIteratorFn(async () => {
@@ -531,7 +531,7 @@ export abstract class Dataset<T extends DataElement> {
  * await ds.forEachAsync(e => console.log(e));
  * ```
  */
-export function datasetFromIteratorFn<T extends DataElement>(
+export function datasetFromIteratorFn<T extends tf.TensorContainer>(
     iteratorFn: () => Promise<LazyIterator<T>>,
     size: number = null): Dataset<T> {
   return new class extends Dataset<T> {
@@ -565,7 +565,7 @@ export function datasetFromIteratorFn<T extends DataElement>(
  * @param items An array of elements that will be parsed as items in a dataset.
  */
 /** @doc {heading: 'Data', subheading: 'Creation', namespace: 'data'} */
-export function array<T extends DataElement>(items: T[]): Dataset<T> {
+export function array<T extends tf.TensorContainer>(items: T[]): Dataset<T> {
   return datasetFromIteratorFn(
       async () => iteratorFromItems(items), items.length);
 }
@@ -610,7 +610,7 @@ export function array<T extends DataElement>(items: T[]): Dataset<T> {
  * ```
  */
 /** @doc {heading: 'Data', subheading: 'Operations', namespace: 'data'} */
-export function zip<O extends DataElement>(datasets: DatasetContainer):
+export function zip<O extends tf.TensorContainer>(datasets: DatasetContainer):
     Dataset<O> {
   // manually type-check the argument for JS users
   if (!isIterable(datasets)) {

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -22,7 +22,7 @@ import {describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
 import {array} from './dataset';
 import * as tfd from './index';
 import {iteratorFromItems, LazyIterator} from './iterators/lazy_iterator';
-import {DataElementObject, DatasetContainer} from './types';
+import {DatasetContainer} from './types';
 
 class TestObjectIterator extends LazyIterator<{}> {
   data = Array.from({length: 100}, (v, k) => k);
@@ -55,7 +55,7 @@ class TestObjectIterator extends LazyIterator<{}> {
   }
 }
 
-export class TestDataset extends tfd.Dataset<DataElementObject> {
+export class TestDataset extends tfd.Dataset<TensorContainerObject> {
   readonly size: number;
   constructor(setSize = false) {
     super();

--- a/src/datasets/csv_dataset.ts
+++ b/src/datasets/csv_dataset.ts
@@ -16,11 +16,11 @@
  * =============================================================================
  */
 
-import {util} from '@tensorflow/tfjs-core';
+import {TensorContainer, util} from '@tensorflow/tfjs-core';
 import {Dataset} from '../dataset';
 import {DataSource} from '../datasource';
 import {LazyIterator} from '../iterators/lazy_iterator';
-import {ColumnConfig, CSVConfig, DataElement} from '../types';
+import {ColumnConfig, CSVConfig} from '../types';
 import {TextLineDataset} from './text_line_dataset';
 
 const CODE_QUOTE = '"';
@@ -42,7 +42,7 @@ const STATE_WITHIN_QUOTE_IN_QUOTE = Symbol('quoteinquote');
  * The results are not batched.
  */
 /** @doc {heading: 'Data', subheading: 'Classes', namespace: 'data'} */
-export class CSVDataset extends Dataset<DataElement> {
+export class CSVDataset extends Dataset<TensorContainer> {
   base: TextLineDataset;
   private hasHeader = true;
   private fullColumnNames: string[] = null;
@@ -180,7 +180,7 @@ export class CSVDataset extends Dataset<DataElement> {
     this.delimiter = csvConfig.delimiter ? csvConfig.delimiter : ',';
   }
 
-  async iterator(): Promise<LazyIterator<DataElement>> {
+  async iterator(): Promise<LazyIterator<TensorContainer>> {
     if (!this.columnNamesValidated) {
       await this.setColumnNames();
     }
@@ -193,10 +193,10 @@ export class CSVDataset extends Dataset<DataElement> {
     return lines.map(x => this.makeDataElement(x));
   }
 
-  makeDataElement(line: string): DataElement {
+  makeDataElement(line: string): TensorContainer {
     const values = this.parseRow(line);
-    const features: {[key: string]: DataElement} = {};
-    const labels: {[key: string]: DataElement} = {};
+    const features: {[key: string]: TensorContainer} = {};
+    const labels: {[key: string]: TensorContainer} = {};
 
     for (let i = 0; i < this.fullColumnNames.length; i++) {
       const key = this.fullColumnNames[i];

--- a/src/datasets/csv_dataset.ts
+++ b/src/datasets/csv_dataset.ts
@@ -33,7 +33,7 @@ const STATE_WITHIN_QUOTE_IN_QUOTE = Symbol('quoteinquote');
 /**
  * Represents a potentially large collection of delimited text records.
  *
- * The produced `DataElement`s each contain one key-value pair for
+ * The produced `TensorContainer`s each contain one key-value pair for
  * every column of the table.  When a field is empty in the incoming data, the
  * resulting value is `undefined`, or throw error if it is required.  Values
  * that can be parsed as numbers are emitted as type `number`, other values

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,5 +21,5 @@ export {TextLineDataset} from './datasets/text_line_dataset';
 export {csv, func, generator} from './readers';
 export {FileDataSource} from './sources/file_data_source';
 export {URLDataSource} from './sources/url_data_source';
-export {ColumnConfig, DataElement} from './types';
+export {ColumnConfig} from './types';
 export {version as version_data} from './version';

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,5 +21,5 @@ export {TextLineDataset} from './datasets/text_line_dataset';
 export {csv, func, generator} from './readers';
 export {FileDataSource} from './sources/file_data_source';
 export {URLDataSource} from './sources/url_data_source';
-export {ColumnConfig} from './types';
+export {ColumnConfig, DataElement} from './types';
 export {version as version_data} from './version';

--- a/src/iterators/lazy_iterator.ts
+++ b/src/iterators/lazy_iterator.ts
@@ -18,7 +18,7 @@
 
 import * as tf from '@tensorflow/tfjs-core';
 import * as seedrandom from 'seedrandom';
-import {DataElement, IteratorContainer} from '../types';
+import {IteratorContainer} from '../types';
 import {deepMapAndAwaitAll, DeepMapAsyncResult, DeepMapResult, deepZip, zipToList} from '../util/deep_map';
 import {GrowingRingBuffer} from '../util/growing_ring_buffer';
 import {RingBuffer} from '../util/ring_buffer';
@@ -126,7 +126,7 @@ export function iteratorFromConcatenatedFunction<T>(
  * `ZipMismatchMode.LONGEST` causes the zipped stream to continue, filling
  * in nulls for the exhausted streams, until all streams are exhausted.
  */
-export function iteratorFromZipped<O extends DataElement>(
+export function iteratorFromZipped<O extends tf.TensorContainer>(
     iterators: IteratorContainer,
     mismatchMode: ZipMismatchMode = ZipMismatchMode.FAIL): LazyIterator<O> {
   return new ZipIterator<O>(iterators, mismatchMode);
@@ -381,7 +381,7 @@ export abstract class LazyIterator<T> {
       batchSize: number, smallLastBatch = true,
       // tslint:disable-next-line:no-any
       zipFn: (xs: any[]) => DeepMapResult = zipToList):
-      LazyIterator<DataElement> {
+      LazyIterator<tf.TensorContainer> {
     // First collect the desired number of input elements as a row-major batch.
     const rowBatches = this.rowMajorBatch(batchSize, smallLastBatch);
     // Now 'rotate' or 'pivot' the data, collecting all values from each column
@@ -1011,7 +1011,7 @@ export enum ZipMismatchMode {
  * `ZipMismatchMode.LONGEST` causes the zipped stream to continue, filling
  * in nulls for the exhausted streams, until all streams are exhausted.
  */
-class ZipIterator<O extends DataElement> extends LazyIterator<O> {
+class ZipIterator<O extends tf.TensorContainer> extends LazyIterator<O> {
   private count = 0;
   private currentPromise: Promise<IteratorResult<O>> = null;
 

--- a/src/iterators/lazy_iterator_test.ts
+++ b/src/iterators/lazy_iterator_test.ts
@@ -460,7 +460,7 @@ describe('LazyIterator', () => {
    * API, but that may not be what users ultimately want when zipping dicts.
    * This may merit a convenience function (e.g., maybe flatZip()).
    */
-  it('zipping DataElement streams requires manual merge', async () => {
+  it('zipping TensorContainer streams requires manual merge', async () => {
     function naiveMerge(xs: TensorContainer[]): TensorContainer {
       const result = {};
       for (const x of xs) {

--- a/src/iterators/lazy_iterator_test.ts
+++ b/src/iterators/lazy_iterator_test.ts
@@ -16,7 +16,7 @@
  * =============================================================================
  */
 
-import {DataElement, DataElementArray, DataElementObject} from '../types';
+import {TensorContainer, TensorContainerArray, TensorContainerObject} from '@tensorflow/tfjs-core';
 import {iteratorFromConcatenated, iteratorFromConcatenatedFunction, iteratorFromFunction, iteratorFromIncrementing, iteratorFromItems, iteratorFromZipped, LazyIterator, ZipMismatchMode} from './lazy_iterator';
 
 export class TestIntegerIterator extends LazyIterator<number> {
@@ -358,7 +358,7 @@ describe('LazyIterator', () => {
     // each result has the form [x, x * 10, 'string ' + x]
 
     for (const e of result) {
-      const ee = e as DataElementArray;
+      const ee = e as TensorContainerArray;
       expect(ee[1]).toEqual(ee[0] as number * 10);
       expect(ee[2]).toEqual(`string ${ee[0]}`);
     }
@@ -375,7 +375,7 @@ describe('LazyIterator', () => {
     // each result has the form {a: x, b: x * 10, c: 'string ' + x}
 
     for (const e of result) {
-      const ee = e as DataElementObject;
+      const ee = e as TensorContainerObject;
       expect(ee['b']).toEqual(ee['a'] as number * 10);
       expect(ee['c']).toEqual(`string ${ee['a']}`);
     }
@@ -398,10 +398,10 @@ describe('LazyIterator', () => {
     // ]
 
     for (const e of result) {
-      const ee = e as DataElementArray;
-      const aa = ee[0] as DataElementObject;
-      const bb = ee[1] as DataElementObject;
-      const cc = ee[2] as DataElementObject;
+      const ee = e as TensorContainerArray;
+      const aa = ee[0] as TensorContainerObject;
+      const bb = ee[1] as TensorContainerObject;
+      const cc = ee[2] as TensorContainerObject;
       expect(aa['constant']).toEqual(12);
       expect(bb['b']).toEqual(aa['a'] as number * 10);
       expect(bb['array']).toEqual([
@@ -461,7 +461,7 @@ describe('LazyIterator', () => {
    * This may merit a convenience function (e.g., maybe flatZip()).
    */
   it('zipping DataElement streams requires manual merge', async () => {
-    function naiveMerge(xs: DataElement[]): DataElement {
+    function naiveMerge(xs: TensorContainer[]): TensorContainer {
       const result = {};
       for (const x of xs) {
         // For now, we do nothing to detect name collisions here
@@ -477,14 +477,15 @@ describe('LazyIterator', () => {
     // At first, each result has the form
     // [{a: x}, {b: x * 10}, {c: 'string ' + x}]
 
-    const readStream = zippedStream.map(e => naiveMerge(e as DataElementArray));
+    const readStream =
+        zippedStream.map(e => naiveMerge(e as TensorContainerArray));
     // Now each result has the form {a: x, b: x * 10, c: 'string ' + x}
 
     const result = await readStream.toArrayForTest();
     expect(result.length).toEqual(100);
 
     for (const e of result) {
-      const ee = e as DataElementObject;
+      const ee = e as TensorContainerObject;
       expect(ee['b']).toEqual(ee['a'] as number * 10);
       expect(ee['c']).toEqual(`string ${ee['a']}`);
     }

--- a/src/readers.ts
+++ b/src/readers.ts
@@ -146,7 +146,7 @@ export function func<T extends TensorContainer>(
  * (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_functions).
  *
  * The returned iterator should have `.next()` function that returns element in
- * format of `{value: DataElement, done:boolean}`.
+ * format of `{value: TensorContainer, done:boolean}`.
  *
  * Example of creating a dataset from an iterator factory:
  * ```js

--- a/src/readers.ts
+++ b/src/readers.ts
@@ -16,11 +16,12 @@
  * =============================================================================
  */
 
+import {TensorContainer} from '@tensorflow/tfjs-core';
 import {Dataset, datasetFromIteratorFn} from './dataset';
 import {CSVDataset} from './datasets/csv_dataset';
 import {iteratorFromFunction} from './iterators/lazy_iterator';
 import {URLDataSource} from './sources/url_data_source';
-import {CSVConfig, DataElement} from './types';
+import {CSVConfig} from './types';
 
 /**
  * Create a `CSVDataset` by reading and decoding CSV file(s) from provided URL
@@ -130,7 +131,7 @@ export function csv(
  *
  * @param f A function that produces one data element on each call.
  */
-export function func<T extends DataElement>(
+export function func<T extends TensorContainer>(
     f: () => IteratorResult<T>| Promise<IteratorResult<T>>): Dataset<T> {
   const iter = iteratorFromFunction(f);
   return datasetFromIteratorFn(async () => iter);
@@ -197,7 +198,7 @@ export function func<T extends DataElement>(
  *   configParamIndices: [1]
  *  }
  */
-export function generator<T extends DataElement>(
+export function generator<T extends TensorContainer>(
     generator: () => Iterator<T>| Promise<Iterator<T>>): Dataset<T> {
   return datasetFromIteratorFn(async () => {
     const gen = await generator();

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,13 @@ import {DataType, TensorContainer} from '@tensorflow/tfjs-core';
 import {Dataset} from './dataset';
 import {LazyIterator} from './iterators/lazy_iterator';
 
+/**
+ * @deprecated Use `TensorContainer` from `@tensorflow/tfjs-core` instead.
+ *
+ * JSON-like type representing a nested structure of primitives or Tensors.
+ */
+export type DataElement = TensorContainer;
+
 // Maybe this should be called 'NestedContainer'-- that's just a bit unwieldy.
 export type Container<T> = ContainerObject<T>|ContainerArray<T>;
 
@@ -33,12 +40,12 @@ export interface ContainerArray<T> extends Array<ContainerOrT<T>> {}
 /**
  * A nested structure of Datasets, used as the input to zip().
  */
-export type DatasetContainer = Container<Dataset<TensorContainer>>;
+export type DatasetContainer = Container<Dataset<DataElement>>;
 
 /**
  * A nested structure of LazyIterators, used as the input to zip().
  */
-export type IteratorContainer = Container<LazyIterator<TensorContainer>>;
+export type IteratorContainer = Container<LazyIterator<DataElement>>;
 
 /**
  * Types supported by FileChunkIterator in both Browser and Node Environment.
@@ -65,7 +72,7 @@ export type FileElement = File|Blob|Uint8Array;
 export interface ColumnConfig {
   required?: boolean;
   dtype?: DataType;
-  default?: TensorContainer;
+  default?: DataElement;
   isLabel?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,18 +16,9 @@
  * =============================================================================
  */
 
-import {DataType, TensorContainer, TensorContainerArray, TensorContainerObject} from '@tensorflow/tfjs-core';
+import {DataType, TensorContainer} from '@tensorflow/tfjs-core';
 import {Dataset} from './dataset';
 import {LazyIterator} from './iterators/lazy_iterator';
-
-/**
- * JSON-like type representing a nested structure of primitives or Tensors.
- */
-export type DataElement = TensorContainer;
-
-export type DataElementObject = TensorContainerObject;
-
-export type DataElementArray = TensorContainerArray;
 
 // Maybe this should be called 'NestedContainer'-- that's just a bit unwieldy.
 export type Container<T> = ContainerObject<T>|ContainerArray<T>;
@@ -42,12 +33,12 @@ export interface ContainerArray<T> extends Array<ContainerOrT<T>> {}
 /**
  * A nested structure of Datasets, used as the input to zip().
  */
-export type DatasetContainer = Container<Dataset<DataElement>>;
+export type DatasetContainer = Container<Dataset<TensorContainer>>;
 
 /**
  * A nested structure of LazyIterators, used as the input to zip().
  */
-export type IteratorContainer = Container<LazyIterator<DataElement>>;
+export type IteratorContainer = Container<LazyIterator<TensorContainer>>;
 
 /**
  * Types supported by FileChunkIterator in both Browser and Node Environment.
@@ -74,7 +65,7 @@ export type FileElement = File|Blob|Uint8Array;
 export interface ColumnConfig {
   required?: boolean;
   dtype?: DataType;
-  default?: DataElement;
+  default?: TensorContainer;
   isLabel?: boolean;
 }
 


### PR DESCRIPTION
tfjs-data internal type `DataElement` is a holdover when the repo has to duplicate the type `TensorContainer` from tfjs-core. Now type `TensorContainer` is exported, so tfjs-data should use it directly. 

resolve:https://github.com/tensorflow/tfjs/issues/1187

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/170)
<!-- Reviewable:end -->
