### PR TITLE
Make `seedrandom` peerDependency and cleanup up node util.isPrimitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
     "lint": "tslint -p . -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "1.0.3"
+    "@tensorflow/tfjs-core": "1.0.3",
+    "seedrandom": "~2.4.3"
   },
   "dependencies": {
     "@types/node-fetch": "^2.1.2",
-    "node-fetch": "~2.1.2",
-    "seedrandom": "~2.4.3"
+    "node-fetch": "~2.1.2"
   },
   "browser": {
     "fs": false,

--- a/src/util/deep_map.ts
+++ b/src/util/deep_map.ts
@@ -17,7 +17,6 @@
  */
 
 import * as tf from '@tensorflow/tfjs-core';
-import {isPrimitive} from 'util';
 
 // tslint:disable:no-any
 
@@ -265,4 +264,14 @@ export function canTensorify(obj: any): boolean {
   return obj == null || isPrimitive(obj) || Array.isArray(obj) ||
       (typeof obj === 'object' && (obj instanceof tf.Tensor)) ||
       tf.util.isTypedArray(obj);
+}
+
+/**
+ * Returns true if the given `value` is a primitive type. Otherwise returns
+ * false. This is equivalant to node util.isPrimitive
+ */
+function isPrimitive(value: any): boolean {
+  return (
+      (typeof value !== 'object' && typeof value !== 'function') ||
+      value === null);
 }

--- a/src/util/deep_map.ts
+++ b/src/util/deep_map.ts
@@ -272,6 +272,6 @@ export function canTensorify(obj: any): boolean {
  */
 function isPrimitive(value: any): boolean {
   return (
-      (typeof value !== 'object' && typeof value !== 'function') ||
-      value === null);
+      value === null ||
+      (typeof value !== 'object' && typeof value !== 'function'));
 }


### PR DESCRIPTION
1. make `seedrandom` peerDependency because it's already in `@tensorflow/tfjs-core`, and duplicate dependency cause error for tfjs-wechat.
2. replace `util.isPrimitive` which is deprecated according to https://nodejs.org/api/util.html#util_util_isprimitive_object

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/173)
<!-- Reviewable:end -->
