### PR TITLE
Validate fetched csv file

### DIFF
--- a/src/iterators/file_chunk_iterator.ts
+++ b/src/iterators/file_chunk_iterator.ts
@@ -26,6 +26,8 @@ export interface FileChunkIteratorOptions {
   offset?: number;
   /** The number of bytes to read at a time. Default 1MB. */
   chunkSize?: number;
+  /** The content type to validate when downloading file fomr url */
+  urlContentType?: string;
 }
 
 /**

--- a/src/iterators/url_chunk_iterator.ts
+++ b/src/iterators/url_chunk_iterator.ts
@@ -16,7 +16,7 @@
  * =============================================================================
  */
 
-import {ENV} from '@tensorflow/tfjs-core';
+import {ENV, util} from '@tensorflow/tfjs-core';
 import {FileChunkIterator, FileChunkIteratorOptions} from './file_chunk_iterator';
 
 /**
@@ -31,6 +31,8 @@ export async function urlChunkIterator(
   let response;
   if (ENV.get('IS_BROWSER')) {
     response = await fetch(url);
+    validateUrlContentType(
+        response.headers.get('Content-Type'), options.urlContentType);
     if (response.ok) {
       const blob = await response.blob();
       return new FileChunkIterator(blob, options);
@@ -48,11 +50,22 @@ export async function urlChunkIterator(
           'in the node.js environment yet.');
     }
     response = await nodeFetch(url);
+    validateUrlContentType(
+        response.headers.get('Content-Type'), options.urlContentType);
     if (response.ok) {
       const unitArray = await response.buffer();
       return new FileChunkIterator(unitArray, options);
     } else {
       throw new Error(response.statusText);
     }
+  }
+}
+
+function validateUrlContentType(contentType: string, idealContentType: string) {
+  if (idealContentType) {
+    util.assert(
+        contentType === idealContentType,
+        () => `Response Content-Type should be ${idealContentType}, but got ${
+            contentType}`);
   }
 }

--- a/src/readers.ts
+++ b/src/readers.ts
@@ -103,7 +103,8 @@ import {CSVConfig, DataElement} from './types';
  */
 export function csv(
     source: RequestInfo, csvConfig: CSVConfig = {}): CSVDataset {
-  return new CSVDataset(new URLDataSource(source), csvConfig);
+  return new CSVDataset(
+      new URLDataSource(source, {urlContentType: 'text/csv'}), csvConfig);
 }
 
 /**


### PR DESCRIPTION
Check fetch `response.headers.get('Content-Type')` to validate fetched csv file type. 

resolves https://github.com/tensorflow/tfjs/issues/1067

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/174)
<!-- Reviewable:end -->
