### PR TITLE
Remove OS X testing from travis, only test on browserstack on node 10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-os:
-  - linux
-  - osx
 language: node_js
 node_js:
   - '8'

--- a/scripts/test-travis.sh
+++ b/scripts/test-travis.sh
@@ -26,4 +26,7 @@ fi
 yarn build
 yarn lint
 yarn test-node
-yarn test-travis
+
+if [[ $(node -v) = *v10* ]]; then
+  yarn test-travis
+fi


### PR DESCRIPTION
This will make travis much faster (we're running 4x as many browser tests as we need to, which will hog browserstack).

OS X testing is not necessary, we test on real browsers on OS X on Browserstack. We only need to test the browser tests from a single build config as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/179)
<!-- Reviewable:end -->
