### PR TITLE
Update core dependency to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "module": "dist/tf-data.esm.js",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.1.0",
+    "@tensorflow/tfjs-core": "1.1.2",
     "@types/fetch-mock": "^6.0.1",
     "@types/jasmine": "~2.5.53",
     "@types/nock": "9.3.0",
@@ -54,7 +54,7 @@
     "lint": "tslint -p . -t verbose"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "1.1.0",
+    "@tensorflow/tfjs-core": "1.1.2",
     "seedrandom": "~2.4.3"
   },
   "dependencies": {

--- a/src/dataset_test.ts
+++ b/src/dataset_test.ts
@@ -465,7 +465,8 @@ describeAllEnvs('Dataset', () => {
 
     const expectedNumberLastBatch = tf.tensor1d([96, 97, 98, 99]);
     tf.test_util.expectArraysClose(
-        lastBatch['number'] as tf.Tensor, expectedNumberLastBatch);
+        await (lastBatch['number'] as tf.Tensor).array(),
+        await expectedNumberLastBatch.array());
 
     const expectedNumberArrayLastBatch = tf.tensor2d(
         [
@@ -474,7 +475,8 @@ describeAllEnvs('Dataset', () => {
         ],
         [4, 3]);
     tf.test_util.expectArraysClose(
-        lastBatch['numberArray'] as tf.Tensor, expectedNumberArrayLastBatch);
+        await (lastBatch['numberArray'] as tf.Tensor).array(),
+        await expectedNumberArrayLastBatch.array());
 
     const expectedTensorLastBatch = tf.tensor2d(
         [
@@ -483,7 +485,8 @@ describeAllEnvs('Dataset', () => {
         ],
         [4, 3]);
     tf.test_util.expectArraysClose(
-        lastBatch['Tensor'] as tf.Tensor, expectedTensorLastBatch);
+        await (lastBatch['Tensor'] as tf.Tensor).array(),
+        await expectedTensorLastBatch.array());
 
     const expectedTensor2LastBatch = tf.tensor3d(
         [
@@ -494,12 +497,14 @@ describeAllEnvs('Dataset', () => {
         ],
         [4, 2, 2]);
     tf.test_util.expectArraysClose(
-        lastBatch['Tensor2'] as tf.Tensor, expectedTensor2LastBatch);
+        await (lastBatch['Tensor2'] as tf.Tensor).array(),
+        await expectedTensor2LastBatch.array());
 
     const expectedStringLastBatch =
         tf.tensor1d(['Item 96', 'Item 97', 'Item 98', 'Item 99']);
     tf.test_util.expectArraysEqual(
-        lastBatch['string'] as tf.Tensor, expectedStringLastBatch);
+        await (lastBatch['string'] as tf.Tensor).array(),
+        await expectedStringLastBatch.array());
 
     tf.dispose(result);
     tf.dispose(expectedNumberLastBatch);

--- a/src/iterators/webcam_iterator_test.ts
+++ b/src/iterators/webcam_iterator_test.ts
@@ -108,11 +108,12 @@ describeBrowserEnvs('WebcamIterator', () => {
     ]);
     const croppedImg = webcamIterator.cropAndResizeFrame(originalImg);
     test_util.expectArraysClose(
-        croppedImg, tensor3d([
+        await croppedImg.array(),
+        await tensor3d([
           [[6.625, 7.1875, 7.75], [8.3125, 8.875, 9.4375]],
 
           [[1, 1.5625, 2.125], [2.6875, 3.25, 3.8125]]
-        ]));
+        ]).array());
   });
 
   it('resize in bilinear method has correct shape with html element',
@@ -153,11 +154,12 @@ describeBrowserEnvs('WebcamIterator', () => {
          [[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]
        ]);
        const croppedImg = webcamIterator.cropAndResizeFrame(originalImg);
-       test_util.expectArraysClose(croppedImg, tensor3d([
-                                     [[1, 1, 1], [1, 1, 1]],
+       test_util.expectArraysClose(
+           await croppedImg.array(), await tensor3d([
+                                       [[1, 1, 1], [1, 1, 1]],
 
-                                     [[1, 1, 1], [1, 1, 1]]
-                                   ]));
+                                       [[1, 1, 1], [1, 1, 1]]
+                                     ]).array());
      });
 
   it('webcamIterator could stop', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-core@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.0.tgz#028c69291e19c328c4c30e18d29b09135c22cb44"
-  integrity sha512-loPpHGVjiyEb+Ixlsj8prQ/r4exekITn7vM4WEyHUouFKx0/CuoB2FQ0m6DSb/6ApvucxTWGGNTRRo4HK4Ma0Q==
+"@tensorflow/tfjs-core@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.2.tgz#efb8b3688fbff353e51d41a3d832dde8c1bc321d"
+  integrity sha512-xCAUIAh14OFnHt+IQUUZIH/P/jH/EWvewL0Ty6q6USUx4YZ+HvKwNw1G7h/gKki4A31BJ0avD04ylBKc75laGg==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"


### PR DESCRIPTION
Update core dependency to 1.1.2

**Details**
- Fix build errors introduced by change in the signature of `expectArraysEqual/Close` where `Tensor` is not a valid entry anymore, and we want to avoid calling `dataSync() ` in unit tests so we can run unit tests against async-only backends

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/183)
<!-- Reviewable:end -->
