### PR TITLE
Remove import from tfjs-core/dist/util

### DIFF
--- a/src/iterators/webcam_iterator.ts
+++ b/src/iterators/webcam_iterator.ts
@@ -16,8 +16,7 @@
  * =============================================================================
  */
 
-import {browser, ENV, image, tensor1d, Tensor1D, tensor2d, Tensor2D, Tensor3D, Tensor4D} from '@tensorflow/tfjs-core';
-import {assert} from '@tensorflow/tfjs-core/dist/util';
+import {browser, ENV, image, tensor1d, Tensor1D, tensor2d, Tensor2D, Tensor3D, Tensor4D, util} from '@tensorflow/tfjs-core';
 import {WebcamConfig} from '../types';
 import {LazyIterator} from './lazy_iterator';
 
@@ -96,7 +95,7 @@ export class WebcamIterator extends LazyIterator<Tensor3D> {
   // Async function to start video stream.
   async start(): Promise<void> {
     if (this.webcamConfig.facingMode) {
-      assert(
+      util.assert(
           (this.webcamConfig.facingMode === 'user') ||
               (this.webcamConfig.facingMode === 'environment'),
           () =>


### PR DESCRIPTION
The assert function is already exported in tfjs-core under util, so this commit removes the unneeded import from `tfjs-core/dist/util`. Removing this import will reduce the exported package file size a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/185)
<!-- Reviewable:end -->
