### PR TITLE
Fix GPU memory leaks when calling WebcamIterator.capture

### DIFF
--- a/src/iterators/webcam_iterator.ts
+++ b/src/iterators/webcam_iterator.ts
@@ -16,7 +16,7 @@
  * =============================================================================
  */
 
-import {browser, ENV, image, tensor1d, Tensor1D, tensor2d, Tensor2D, Tensor3D, Tensor4D, util} from '@tensorflow/tfjs-core';
+import {browser, ENV, image, tensor1d, Tensor1D, tensor2d, Tensor2D, Tensor3D, Tensor4D, tidy, util} from '@tensorflow/tfjs-core';
 import {WebcamConfig} from '../types';
 import {LazyIterator} from './lazy_iterator';
 
@@ -158,9 +158,11 @@ export class WebcamIterator extends LazyIterator<Tensor3D> {
     }
     if (this.resize) {
       try {
-        return {value: this.cropAndResizeFrame(img), done: false};
+        return { value: this.cropAndResizeFrame(img), done: false };
       } catch (e) {
         throw new Error(`Error thrown cropping the video: ${e.message}`);
+      } finally {
+        img.dispose();
       }
     } else {
       return {value: img, done: false};
@@ -181,14 +183,16 @@ export class WebcamIterator extends LazyIterator<Tensor3D> {
 
   // Cropping and resizing each frame based on config
   cropAndResizeFrame(img: Tensor3D): Tensor3D {
-    const expandedImage: Tensor4D = img.toFloat().expandDims(0);
-    let resizedImage;
-    resizedImage = image.cropAndResize(
+    return tidy(() => {
+      const expandedImage: Tensor4D = img.toFloat().expandDims(0);
+      let resizedImage;
+      resizedImage = image.cropAndResize(
         expandedImage, this.cropBox, this.cropBoxInd, this.cropSize,
         'bilinear');
-    // Extract image from batch cropping.
-    const shape = resizedImage.shape;
-    return resizedImage.reshape(shape.slice(1) as [number, number, number]);
+      // Extract image from batch cropping.
+      const shape = resizedImage.shape;
+      return resizedImage.reshape(shape.slice(1) as [number, number, number]);
+    });
   }
 
   // Capture one frame from the video stream, and extract the value from

--- a/src/iterators/webcam_iterator_test.ts
+++ b/src/iterators/webcam_iterator_test.ts
@@ -16,7 +16,7 @@
  * =============================================================================
  */
 
-import {tensor3d, test_util} from '@tensorflow/tfjs-core';
+import {memory, tensor3d, test_util} from '@tensorflow/tfjs-core';
 import {describeBrowserEnvs, setupFakeVideoStream} from '../util/test_utils';
 import {WebcamIterator} from './webcam_iterator';
 
@@ -206,5 +206,22 @@ describeBrowserEnvs('WebcamIterator', () => {
       expect(result3.done).toBeFalsy();
       expect(result3.value.shape).toEqual([100, 100, 3]);
     }
+  });
+
+  it('capture with cropAndResize has no memory leaks', async () => {
+    const videoElement = document.createElement('video');
+    videoElement.width = 100;
+    videoElement.height = 200;
+    const webcamIterator = await WebcamIterator.create(
+        videoElement, { resizeWidth: 30, resizeHeight: 40, centerCrop: true });
+
+    const before = memory();
+
+    const result = await webcamIterator.capture();
+    result.dispose();
+
+    const after = memory();
+
+    expect(after.numTensors).toEqual(before.numTensors);
   });
 });


### PR DESCRIPTION
Fix GPU memory leaks when calling WebcamIterator.capture.
We can reproduce this memory leak in the following procedure.

1. enable WebGL
2. create WebcamIterator with config which require resize
3. start WebcamIterator
4. capture video
5. dispose image which has captured

```ts
const video = document.querySelector('#video') as HTMLVideoElement;
const webcam = await tf.data.webcam(video, {
  resizeWidth: IMAGE_WIDTH, // different from width of an element #video
  resizeHeight: IMAGE_HEIGHT, // different from height of an element #video
});

await webcam.start();

const image = await webcam.capture();
image.dispose();
```

NOTE : WebcamIterator still has some GPU memory leaks because of that it contains `Tensor`s as private members. I think it is better to consider adding `dispose` method to WebcamIterator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/188)
<!-- Reviewable:end -->
