### PR TITLE
Truncate extra line breaker in Window/DOS format csv

### DIFF
--- a/src/datasets/csv_dataset.ts
+++ b/src/datasets/csv_dataset.ts
@@ -288,10 +288,6 @@ export class CSVDataset extends Dataset<TensorContainer> {
 
   // adapted from https://beta.observablehq.com/@mbostock/streaming-csv
   private parseRow(line: string, validateElementCount = true): string[] {
-    // Windows/DOS format csv file has extra line breaker at the end of line.
-    if (line.endsWith('\r')) {
-      line = line.slice(0, -1);
-    }
     const result: string[] = [];
     let readOffset = 0;
     const readLength = line.length;

--- a/src/datasets/csv_dataset.ts
+++ b/src/datasets/csv_dataset.ts
@@ -288,7 +288,7 @@ export class CSVDataset extends Dataset<TensorContainer> {
 
   // adapted from https://beta.observablehq.com/@mbostock/streaming-csv
   private parseRow(line: string, validateElementCount = true): string[] {
-    // Truncate line breaker at the end of line.
+    // Windows/DOS format csv file has extra line breaker at the end of line.
     if (line.endsWith('\r')) {
       line = line.slice(0, -1);
     }

--- a/src/datasets/csv_dataset.ts
+++ b/src/datasets/csv_dataset.ts
@@ -288,6 +288,10 @@ export class CSVDataset extends Dataset<TensorContainer> {
 
   // adapted from https://beta.observablehq.com/@mbostock/streaming-csv
   private parseRow(line: string, validateElementCount = true): string[] {
+    // Truncate line breaker at the end of line.
+    if (line.endsWith('\r')) {
+      line = line.slice(0, -1);
+    }
     const result: string[] = [];
     let readOffset = 0;
     const readLength = line.length;

--- a/src/datasets/csv_dataset_test.ts
+++ b/src/datasets/csv_dataset_test.ts
@@ -94,7 +94,7 @@ const csvWithMissingElement = `A,B,C
 2,
 3,2,3`;
 
-const csvWithLineBreaker = `A,B,C\r\n1,2,3\r\nv,\rw,x\r\n3,2,3`;
+const csvWithDOSLineBreaker = `A,B,C\r\n1,2,3\r\nv,\rw,x\r\n3,2,3`;
 
 const csvDataWithHeadersExtra = ENV.get('IS_BROWSER') ?
     new Blob([csvDataExtra]) :
@@ -115,9 +115,9 @@ const csvDataWithMissingElement = ENV.get('IS_BROWSER') ?
 const csvDataWithSingleWhitespace = ENV.get('IS_BROWSER') ?
     new Blob([csvWithSingleWhitespace]) :
     Buffer.from(csvWithSingleWhitespace);
-const csvDataWithLineBreaker = ENV.get('IS_BROWSER') ?
-    new Blob([csvWithLineBreaker]) :
-    Buffer.from(csvWithLineBreaker);
+const csvDataWithDOSLineBreaker = ENV.get('IS_BROWSER') ?
+    new Blob([csvWithDOSLineBreaker]) :
+    Buffer.from(csvWithDOSLineBreaker);
 
 describe('CSVDataset', () => {
   it('produces a stream of dicts containing UTF8-decoded csv data',
@@ -495,7 +495,8 @@ describe('CSVDataset', () => {
      });
 
   it('parse correctly when csv file has extra line breaker', async () => {
-    const source = new FileDataSource(csvDataWithLineBreaker, {chunkSize: 10});
+    const source =
+        new FileDataSource(csvDataWithDOSLineBreaker, {chunkSize: 10});
     const dataset = new CSVDataset(source);
     expect(await dataset.columnNames()).toEqual(['A', 'B', 'C']);
     const iter = await dataset.iterator();

--- a/src/datasets/csv_dataset_test.ts
+++ b/src/datasets/csv_dataset_test.ts
@@ -94,7 +94,7 @@ const csvWithMissingElement = `A,B,C
 2,
 3,2,3`;
 
-const csvWithLineBreaker = `A,B,C\r\n1,2,3\r\n3,2,3`;
+const csvWithLineBreaker = `A,B,C\r\n1,2,3\r\nv,\rw,x\r\n3,2,3`;
 
 const csvDataWithHeadersExtra = ENV.get('IS_BROWSER') ?
     new Blob([csvDataExtra]) :
@@ -494,7 +494,7 @@ describe('CSVDataset', () => {
        }
      });
 
-  fit('parse correctly when csv file has extra line breaker', async () => {
+  it('parse correctly when csv file has extra line breaker', async () => {
     const source = new FileDataSource(csvDataWithLineBreaker, {chunkSize: 10});
     const dataset = new CSVDataset(source);
     expect(await dataset.columnNames()).toEqual(['A', 'B', 'C']);
@@ -502,6 +502,7 @@ describe('CSVDataset', () => {
     const result = await iter.toArrayForTest();
 
     expect(result[0]).toEqual({A: 1, B: 2, C: 3});
-    expect(result[1]).toEqual({A: 3, B: 2, C: 3});
+    expect(result[1]).toEqual({A: 'v', B: '\rw', C: 'x'});
+    expect(result[2]).toEqual({A: 3, B: 2, C: 3});
   });
 });

--- a/src/datasets/csv_dataset_test.ts
+++ b/src/datasets/csv_dataset_test.ts
@@ -94,6 +94,8 @@ const csvWithMissingElement = `A,B,C
 2,
 3,2,3`;
 
+const csvWithLineBreaker = `A,B,C\r\n1,2,3\r\n3,2,3`;
+
 const csvDataWithHeadersExtra = ENV.get('IS_BROWSER') ?
     new Blob([csvDataExtra]) :
     Buffer.from(csvDataExtra);
@@ -113,6 +115,9 @@ const csvDataWithMissingElement = ENV.get('IS_BROWSER') ?
 const csvDataWithSingleWhitespace = ENV.get('IS_BROWSER') ?
     new Blob([csvWithSingleWhitespace]) :
     Buffer.from(csvWithSingleWhitespace);
+const csvDataWithLineBreaker = ENV.get('IS_BROWSER') ?
+    new Blob([csvWithLineBreaker]) :
+    Buffer.from(csvWithLineBreaker);
 
 describe('CSVDataset', () => {
   it('produces a stream of dicts containing UTF8-decoded csv data',
@@ -488,4 +493,15 @@ describe('CSVDataset', () => {
          done();
        }
      });
+
+  fit('parse correctly when csv file has extra line breaker', async () => {
+    const source = new FileDataSource(csvDataWithLineBreaker, {chunkSize: 10});
+    const dataset = new CSVDataset(source);
+    expect(await dataset.columnNames()).toEqual(['A', 'B', 'C']);
+    const iter = await dataset.iterator();
+    const result = await iter.toArrayForTest();
+
+    expect(result[0]).toEqual({A: 1, B: 2, C: 3});
+    expect(result[1]).toEqual({A: 3, B: 2, C: 3});
+  });
 });

--- a/src/datasets/text_line_dataset.ts
+++ b/src/datasets/text_line_dataset.ts
@@ -38,7 +38,13 @@ export class TextLineDataset extends Dataset<string> {
   async iterator(): Promise<LazyIterator<string>> {
     const inputIterator = await this.input.iterator();
     const utf8Iterator = inputIterator.decodeUTF8();
-    const lineIterator = utf8Iterator.split('\n');
+    const lineIterator = utf8Iterator.split('\n').map(line => {
+      // Windows/DOS format text file has extra line breaker at the end of line.
+      if (line.endsWith('\r')) {
+        line = line.slice(0, -1);
+      }
+      return line;
+    });
     return lineIterator;
   }
 }

--- a/src/datasets/text_line_dataset_test.ts
+++ b/src/datasets/text_line_dataset_test.ts
@@ -24,7 +24,13 @@ const runes = `ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷ�
 ᛋᚳᛖᚪᛚ᛫ᚦᛖᚪᚻ᛫ᛗᚪᚾᚾᚪ᛫ᚷᛖᚻᚹᛦᛚᚳ᛫ᛗᛁᚳᛚᚢᚾ᛫ᚻᛦᛏ᛫ᛞᚫᛚᚪᚾ
 ᚷᛁᚠ᛫ᚻᛖ᛫ᚹᛁᛚᛖ᛫ᚠᚩᚱ᛫ᛞᚱᛁᚻᛏᚾᛖ᛫ᛞᚩᛗᛖᛋ᛫ᚻᛚᛇᛏᚪᚾ᛬`;
 
+const textFromWindows = 'abc\rdefg\r\nhijklmn\r\nopqrst';
+
 const testBlob = ENV.get('IS_BROWSER') ? new Blob([runes]) : Buffer.from(runes);
+
+const textBlobFromWindows = ENV.get('IS_BROWSER') ?
+    new Blob([textFromWindows]) :
+    Buffer.from(textFromWindows);
 
 describe('TextLineDataset', () => {
   it('Produces a stream of strings containing UTF8-decoded text lines',
@@ -40,4 +46,15 @@ describe('TextLineDataset', () => {
          'ᚷᛁᚠ᛫ᚻᛖ᛫ᚹᛁᛚᛖ᛫ᚠᚩᚱ᛫ᛞᚱᛁᚻᛏᚾᛖ᛫ᛞᚩᛗᛖᛋ᛫ᚻᛚᛇᛏᚪᚾ᛬',
        ]);
      });
+
+  it('Parses lines from windows text correctly', async () => {
+    const source = new FileDataSource(textBlobFromWindows, {chunkSize: 10});
+    const dataset = new TextLineDataset(source);
+    const iter = await dataset.iterator();
+    const result = await iter.toArrayForTest();
+
+    expect(result[0]).toEqual('abc\rdefg');
+    expect(result[1]).toEqual('hijklmn');
+    expect(result[2]).toEqual('opqrst');
+  });
 });

--- a/src/datasets/text_line_dataset_test.ts
+++ b/src/datasets/text_line_dataset_test.ts
@@ -24,13 +24,13 @@ const runes = `ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷ�
 ᛋᚳᛖᚪᛚ᛫ᚦᛖᚪᚻ᛫ᛗᚪᚾᚾᚪ᛫ᚷᛖᚻᚹᛦᛚᚳ᛫ᛗᛁᚳᛚᚢᚾ᛫ᚻᛦᛏ᛫ᛞᚫᛚᚪᚾ
 ᚷᛁᚠ᛫ᚻᛖ᛫ᚹᛁᛚᛖ᛫ᚠᚩᚱ᛫ᛞᚱᛁᚻᛏᚾᛖ᛫ᛞᚩᛗᛖᛋ᛫ᚻᛚᛇᛏᚪᚾ᛬`;
 
-const textFromWindows = 'abc\rdefg\r\nhijklmn\r\nopqrst';
+const textWithDOSLineBreaks = 'abc\rdefg\r\nhijklmn\r\nopqrst';
 
 const testBlob = ENV.get('IS_BROWSER') ? new Blob([runes]) : Buffer.from(runes);
 
-const textBlobFromWindows = ENV.get('IS_BROWSER') ?
-    new Blob([textFromWindows]) :
-    Buffer.from(textFromWindows);
+const textBlobWithDOSLineBreaks = ENV.get('IS_BROWSER') ?
+    new Blob([textWithDOSLineBreaks]) :
+    Buffer.from(textWithDOSLineBreaks);
 
 describe('TextLineDataset', () => {
   it('Produces a stream of strings containing UTF8-decoded text lines',
@@ -47,12 +47,14 @@ describe('TextLineDataset', () => {
        ]);
      });
 
-  it('Parses lines from windows text correctly', async () => {
-    const source = new FileDataSource(textBlobFromWindows, {chunkSize: 10});
+  it('Parses lines from windows/DOS text correctly', async () => {
+    const source =
+        new FileDataSource(textBlobWithDOSLineBreaks, {chunkSize: 10});
     const dataset = new TextLineDataset(source);
     const iter = await dataset.iterator();
     const result = await iter.toArrayForTest();
 
+    // \r is retained when not followed by \n
     expect(result[0]).toEqual('abc\rdefg');
     expect(result[1]).toEqual('hijklmn');
     expect(result[2]).toEqual('opqrst');


### PR DESCRIPTION
Windows/DOS format csv file has extra line breaker `\r` at the end of line. Truncate it if line endsWith('\r')

Fix: https://github.com/tensorflow/tfjs/issues/1393

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/191)
<!-- Reviewable:end -->
