### PR TITLE
Add browser.crypto: false to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "browser": {
     "fs": false,
     "node-fetch": false,
-    "string_decoder": false
+    "string_decoder": false,
+    "crypto": false
   }
 }


### PR DESCRIPTION
Adding `browser.crypto: false` to `package.json` results in not including crypto and its dependencies when using `browserify` or `parcel` as bundlers for an end application.

Test used:
I made a hello-world js application that depends on tfjs-core and tfjs-data and built it with parcel
Expected my bundle to be ~550kb, but I got 860kb. This fixed the issue.

Analogous PR in tfjs-core: https://github.com/tensorflow/tfjs-core/pull/1821

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/200)
<!-- Reviewable:end -->
