### PR TITLE
add miniprogram entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "types": "dist/index.d.ts",
   "jsnext:main": "dist/tf-data.esm.js",
   "module": "dist/tf-data.esm.js",
+  "miniprogram": "dist/miniprogram",
   "license": "Apache-2.0",
   "devDependencies": {
     "@tensorflow/tfjs-core": "1.1.2",

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -21,5 +21,11 @@ yarn
 
 yarn build
 rollup -c
+
+# Use minified files for miniprogram
+mkdir dist/miniprogram
+cp dist/tf-data.min.js dist/miniprogram/index.js
+cp dist/tf-data.min.js.map dist/miniprogram/index.js.map
+
 echo "Stored standalone library at dist/tfjs-data(.min).js"
 npm pack


### PR DESCRIPTION
Wechat mini app has a size limit, and their minification can not reduce the size as good as ours.
create a dist/miniprogram directory and copy the minified version of tf-data there.
ref https://github.com/tensorflow/tfjs-wechat/issues/13
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-data/202)
<!-- Reviewable:end -->
